### PR TITLE
adds protocol support for `redis` and `rediss`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+    * Add 'redis://' and 'rediss://' protocol support
     * Update `ResponseT` type hint
     * Allow to control the minimum SSL version
     * Add an optional lock_name attribute to LockError.

--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -303,6 +303,7 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
+
 @pytest.mark.parametrize("connection_protocol", ["valkey", "redis"])
 class TestConnectionPoolURLParsing:
     def test_hostname(self, connection_protocol):
@@ -311,7 +312,9 @@ class TestConnectionPoolURLParsing:
         assert pool.connection_kwargs == {"host": "my.host"}
 
     def test_quoted_hostname(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://my %2F host %2B%3D+")
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://my %2F host %2B%3D+"
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "my / host +=+"}
 
@@ -322,7 +325,9 @@ class TestConnectionPoolURLParsing:
 
     @skip_if_server_version_lt("6.0.0")
     def test_username(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://myuser:@localhost")
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://myuser:@localhost"
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "username": "myuser"}
 
@@ -338,7 +343,9 @@ class TestConnectionPoolURLParsing:
         }
 
     def test_password(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://:mypassword@localhost")
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://:mypassword@localhost"
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "password": "mypassword"}
 
@@ -354,7 +361,9 @@ class TestConnectionPoolURLParsing:
 
     @skip_if_server_version_lt("6.0.0")
     def test_username_and_password(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://myuser:mypass@localhost")
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://myuser:mypass@localhost"
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {
             "host": "localhost",
@@ -363,17 +372,23 @@ class TestConnectionPoolURLParsing:
         }
 
     def test_db_as_argument(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost", db=1)
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://localhost", db=1
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "db": 1}
 
     def test_db_in_path(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost/2", db=1)
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://localhost/2", db=1
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "db": 2}
 
     def test_db_in_querystring(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost/2?db=3", db=1)
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://localhost/2?db=3", db=1
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "db": 3}
 
@@ -393,7 +408,6 @@ class TestConnectionPoolURLParsing:
         }
         assert pool.max_connections == 10
 
-
     def test_client_name_in_querystring(self, connection_protocol):
         pool = valkey.ConnectionPool.from_url(
             f"{connection_protocol}://location?client_name=test-client"
@@ -407,18 +421,23 @@ class TestConnectionPoolURLParsing:
             )
 
     def test_extra_querystring_options(self, connection_protocol):
-        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost?a=1&b=2")
+        pool = valkey.ConnectionPool.from_url(
+            f"{connection_protocol}://localhost?a=1&b=2"
+        )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "a": "1", "b": "2"}
 
     def test_calling_from_subclass_returns_correct_instance(self, connection_protocol):
-        pool = valkey.BlockingConnectionPool.from_url(f"{connection_protocol}://localhost")
+        pool = valkey.BlockingConnectionPool.from_url(
+            f"{connection_protocol}://localhost"
+        )
         assert isinstance(pool, valkey.BlockingConnectionPool)
 
     def test_client_creates_connection_pool(self, connection_protocol):
         r = valkey.Valkey.from_url(f"{connection_protocol}://myhost")
         assert r.connection_pool.connection_class == valkey.Connection
         assert r.connection_pool.connection_kwargs == {"host": "myhost"}
+
 
 def test_invalid_scheme_raises_error():
     with pytest.raises(ValueError) as cm:
@@ -427,6 +446,7 @@ def test_invalid_scheme_raises_error():
         "Valkey URL must specify one of the following schemes "
         "(valkey://, valkeys://, redis://, rediss://, unix://)"
     )
+
 
 def test_boolean_parsing():
     for expected, value in (
@@ -447,6 +467,7 @@ def test_boolean_parsing():
         (True, "Yes"),
     ):
         assert expected is to_bool(value)
+
 
 class TestBlockingConnectionPoolURLParsing:
     def test_extra_typed_querystring_options(self):
@@ -542,6 +563,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_class == valkey.UnixDomainSocketConnection
         assert pool.connection_kwargs == {"path": "/socket", "a": "1", "b": "2"}
 
+
 @pytest.mark.skipif(not SSL_AVAILABLE, reason="SSL not installed")
 @pytest.mark.parametrize("connection_protocol", ["valkeys", "rediss"])
 class TestSSLConnectionURLParsing:
@@ -557,19 +579,29 @@ class TestSSLConnectionURLParsing:
             def get_connection(self, *args, **kwargs):
                 return self.make_connection()
 
-        pool = DummyConnectionPool.from_url(f"{connection_protocol}://?ssl_cert_reqs=none")
+        pool = DummyConnectionPool.from_url(
+            f"{connection_protocol}://?ssl_cert_reqs=none"
+        )
         assert pool.get_connection("_").cert_reqs == ssl.CERT_NONE
 
-        pool = DummyConnectionPool.from_url(f"{connection_protocol}://?ssl_cert_reqs=optional")
+        pool = DummyConnectionPool.from_url(
+            f"{connection_protocol}://?ssl_cert_reqs=optional"
+        )
         assert pool.get_connection("_").cert_reqs == ssl.CERT_OPTIONAL
 
-        pool = DummyConnectionPool.from_url(f"{connection_protocol}://?ssl_cert_reqs=required")
+        pool = DummyConnectionPool.from_url(
+            f"{connection_protocol}://?ssl_cert_reqs=required"
+        )
         assert pool.get_connection("_").cert_reqs == ssl.CERT_REQUIRED
 
-        pool = DummyConnectionPool.from_url(f"{connection_protocol}://?ssl_check_hostname=False")
+        pool = DummyConnectionPool.from_url(
+            f"{connection_protocol}://?ssl_check_hostname=False"
+        )
         assert pool.get_connection("_").check_hostname is False
 
-        pool = DummyConnectionPool.from_url(f"{connection_protocol}://?ssl_check_hostname=True")
+        pool = DummyConnectionPool.from_url(
+            f"{connection_protocol}://?ssl_check_hostname=True"
+        )
         assert pool.get_connection("_").check_hostname is True
 
 

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -196,7 +196,6 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
-
 @pytest.mark.parametrize("connection_protocol", ["valkey", "redis"])
 class TestConnectionPoolURLParsing:
     def test_hostname(self, connection_protocol):

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -196,33 +196,33 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
-
+@pytest.mark.parametrize("connection_protocol", ["valkey", "redis"])
 class TestConnectionPoolURLParsing:
-    def test_hostname(self):
-        pool = valkey.ConnectionPool.from_url("valkey://my.host")
+    def test_hostname(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://my.host")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "my.host"}
 
-    def test_quoted_hostname(self):
-        pool = valkey.ConnectionPool.from_url("valkey://my %2F host %2B%3D+")
+    def test_quoted_hostname(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://my %2F host %2B%3D+")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "my / host +=+"}
 
-    def test_port(self):
-        pool = valkey.ConnectionPool.from_url("valkey://localhost:6380")
+    def test_port(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost:6380")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "port": 6380}
 
     @skip_if_server_version_lt("6.0.0")
-    def test_username(self):
-        pool = valkey.ConnectionPool.from_url("valkey://myuser:@localhost")
+    def test_username(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://myuser:@localhost")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "username": "myuser"}
 
     @skip_if_server_version_lt("6.0.0")
-    def test_quoted_username(self):
+    def test_quoted_username(self, connection_protocol):
         pool = valkey.ConnectionPool.from_url(
-            "valkey://%2Fmyuser%2F%2B name%3D%24+:@localhost"
+            f"{connection_protocol}://%2Fmyuser%2F%2B name%3D%24+:@localhost"
         )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {
@@ -230,14 +230,14 @@ class TestConnectionPoolURLParsing:
             "username": "/myuser/+ name=$+",
         }
 
-    def test_password(self):
-        pool = valkey.ConnectionPool.from_url("valkey://:mypassword@localhost")
+    def test_password(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://:mypassword@localhost")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "password": "mypassword"}
 
-    def test_quoted_password(self):
+    def test_quoted_password(self, connection_protocol):
         pool = valkey.ConnectionPool.from_url(
-            "valkey://:%2Fmypass%2F%2B word%3D%24+@localhost"
+            f"{connection_protocol}://:%2Fmypass%2F%2B word%3D%24+@localhost"
         )
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {
@@ -246,8 +246,8 @@ class TestConnectionPoolURLParsing:
         }
 
     @skip_if_server_version_lt("6.0.0")
-    def test_username_and_password(self):
-        pool = valkey.ConnectionPool.from_url("valkey://myuser:mypass@localhost")
+    def test_username_and_password(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://myuser:mypass@localhost")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {
             "host": "localhost",
@@ -255,24 +255,24 @@ class TestConnectionPoolURLParsing:
             "password": "mypass",
         }
 
-    def test_db_as_argument(self):
-        pool = valkey.ConnectionPool.from_url("valkey://localhost", db=1)
+    def test_db_as_argument(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost", db=1)
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "db": 1}
 
-    def test_db_in_path(self):
-        pool = valkey.ConnectionPool.from_url("valkey://localhost/2", db=1)
+    def test_db_in_path(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost/2", db=1)
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "db": 2}
 
-    def test_db_in_querystring(self):
-        pool = valkey.ConnectionPool.from_url("valkey://localhost/2?db=3", db=1)
+    def test_db_in_querystring(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost/2?db=3", db=1)
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "db": 3}
 
-    def test_extra_typed_querystring_options(self):
+    def test_extra_typed_querystring_options(self, connection_protocol):
         pool = valkey.ConnectionPool.from_url(
-            "valkey://localhost/2?socket_timeout=20&socket_connect_timeout=10"
+            f"{connection_protocol}://localhost/2?socket_timeout=20&socket_connect_timeout=10"
             "&socket_keepalive=&retry_on_timeout=Yes&max_connections=10"
         )
 
@@ -286,67 +286,67 @@ class TestConnectionPoolURLParsing:
         }
         assert pool.max_connections == 10
 
-    def test_boolean_parsing(self):
-        for expected, value in (
-            (None, None),
-            (None, ""),
-            (False, 0),
-            (False, "0"),
-            (False, "f"),
-            (False, "F"),
-            (False, "False"),
-            (False, "n"),
-            (False, "N"),
-            (False, "No"),
-            (True, 1),
-            (True, "1"),
-            (True, "y"),
-            (True, "Y"),
-            (True, "Yes"),
-        ):
-            assert expected is to_bool(value)
-
-    def test_client_name_in_querystring(self):
+    def test_client_name_in_querystring(self, connection_protocol):
         pool = valkey.ConnectionPool.from_url(
-            "valkey://location?client_name=test-client"
+            f"{connection_protocol}://location?client_name=test-client"
         )
         assert pool.connection_kwargs["client_name"] == "test-client"
 
-    def test_invalid_extra_typed_querystring_options(self):
+    def test_invalid_extra_typed_querystring_options(self, connection_protocol):
         with pytest.raises(ValueError):
             valkey.ConnectionPool.from_url(
-                "valkey://localhost/2?socket_timeout=_&socket_connect_timeout=abc"
+                f"{connection_protocol}://localhost/2?socket_timeout=_&socket_connect_timeout=abc"
             )
 
-    def test_extra_querystring_options(self):
-        pool = valkey.ConnectionPool.from_url("valkey://localhost?a=1&b=2")
+    def test_extra_querystring_options(self, connection_protocol):
+        pool = valkey.ConnectionPool.from_url(f"{connection_protocol}://localhost?a=1&b=2")
         assert pool.connection_class == valkey.Connection
         assert pool.connection_kwargs == {"host": "localhost", "a": "1", "b": "2"}
 
-    def test_calling_from_subclass_returns_correct_instance(self):
+    def test_calling_from_subclass_returns_correct_instance(self, connection_protocol):
         pool = valkey.BlockingConnectionPool.from_url("valkey://localhost")
         assert isinstance(pool, valkey.BlockingConnectionPool)
 
-    def test_client_creates_connection_pool(self):
-        r = valkey.Valkey.from_url("valkey://myhost")
+    def test_client_creates_connection_pool(self, connection_protocol):
+        r = valkey.Valkey.from_url(f"{connection_protocol}://myhost")
         assert r.connection_pool.connection_class == valkey.Connection
         assert r.connection_pool.connection_kwargs == {"host": "myhost"}
 
-    def test_invalid_scheme_raises_error(self):
-        with pytest.raises(ValueError) as cm:
-            valkey.ConnectionPool.from_url("localhost")
-        assert str(cm.value) == (
-            "Valkey URL must specify one of the following schemes "
-            "(valkey://, valkeys://, unix://)"
-        )
+def test_invalid_scheme_raises_error():
+    with pytest.raises(ValueError) as cm:
+        valkey.ConnectionPool.from_url("localhost")
+    assert str(cm.value) == (
+        "Valkey URL must specify one of the following schemes "
+        "(valkey://, valkeys://, redis://, rediss://, unix://)"
+    )
 
-    def test_invalid_scheme_raises_error_when_double_slash_missing(self):
-        with pytest.raises(ValueError) as cm:
-            valkey.ConnectionPool.from_url("valkey:foo.bar.com:12345")
-        assert str(cm.value) == (
-            "Valkey URL must specify one of the following schemes "
-            "(valkey://, valkeys://, unix://)"
-        )
+def test_invalid_scheme_raises_error_when_double_slash_missing():
+    with pytest.raises(ValueError) as cm:
+        valkey.ConnectionPool.from_url("valkey:foo.bar.com:12345")
+    assert str(cm.value) == (
+        "Valkey URL must specify one of the following schemes "
+        "(valkey://, valkeys://, redis://, rediss://, unix://)"
+    )
+
+def test_boolean_parsing():
+    for expected, value in (
+        (None, None),
+        (None, ""),
+        (False, 0),
+        (False, "0"),
+        (False, "f"),
+        (False, "F"),
+        (False, "False"),
+        (False, "n"),
+        (False, "N"),
+        (False, "No"),
+        (True, 1),
+        (True, "1"),
+        (True, "y"),
+        (True, "Y"),
+        (True, "Yes"),
+    ):
+        assert expected is to_bool(value)
 
 
 class TestBlockingConnectionPoolURLParsing:
@@ -454,6 +454,7 @@ class TestConnectionPoolUnixSocketURLParsing:
 
 
 @pytest.mark.skipif(not SSL_AVAILABLE, reason="SSL not installed")
+@pytest.mark
 class TestSSLConnectionURLParsing:
     def test_host(self):
         pool = valkey.ConnectionPool.from_url("valkeys://my.host")

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -330,24 +330,6 @@ class TestConnectionPoolURLParsing:
         assert r.connection_pool.connection_kwargs == {"host": "myhost"}
 
 
-def test_invalid_scheme_raises_error():
-    with pytest.raises(ValueError) as cm:
-        valkey.ConnectionPool.from_url("localhost")
-    assert str(cm.value) == (
-        "Valkey URL must specify one of the following schemes "
-        "(valkey://, valkeys://, redis://, rediss://, unix://)"
-    )
-
-
-def test_invalid_scheme_raises_error_when_double_slash_missing():
-    with pytest.raises(ValueError) as cm:
-        valkey.ConnectionPool.from_url("valkey:foo.bar.com:12345")
-    assert str(cm.value) == (
-        "Valkey URL must specify one of the following schemes "
-        "(valkey://, valkeys://, redis://, rediss://, unix://)"
-    )
-
-
 def test_boolean_parsing():
     for expected, value in (
         (None, None),

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -196,6 +196,7 @@ class TestBlockingConnectionPool:
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
 
+
 @pytest.mark.parametrize("connection_protocol", ["valkey", "redis"])
 class TestConnectionPoolURLParsing:
     def test_hostname(self, connection_protocol):

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -1030,7 +1030,7 @@ def parse_url(url: str) -> ConnectKwargs:
         "rediss://",
         "unix://",
     )
-    
+
     if not any([url.startswith(scheme) for scheme in valid_schemes]):
         raise ValueError(
             "Valkey URL must specify one of the following "
@@ -1079,7 +1079,6 @@ def parse_url(url: str) -> ConnectKwargs:
 
         if parsed.scheme in ("valkeys", "rediss"):
             kwargs["connection_class"] = SSLConnection
-
 
     return kwargs
 

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -1066,6 +1066,12 @@ def parse_url(url: str) -> ConnectKwargs:
         if parsed.scheme in ("valkeys", "rediss"):
             kwargs["connection_class"] = SSLConnection
 
+    else:
+        valid_schemes = "valkey://, valkeys://, redis://, rediss://, unix://"
+        raise ValueError(
+            f"Valkey URL must specify one of the following schemes ({valid_schemes})"
+        )
+
     return kwargs
 
 

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -1023,6 +1023,20 @@ class ConnectKwargs(TypedDict, total=False):
 
 
 def parse_url(url: str) -> ConnectKwargs:
+    valid_schemes = (
+        "valkey://",
+        "valkeys://",
+        "redis://",
+        "rediss://",
+        "unix://",
+    )
+    
+    if not any([url.startswith(scheme) for scheme in valid_schemes]):
+        raise ValueError(
+            "Valkey URL must specify one of the following "
+            f"schemes ({', '.join(valid_schemes)})"
+        )
+
     parsed: ParseResult = urlparse(url)
     kwargs: ConnectKwargs = {}
 
@@ -1043,13 +1057,13 @@ def parse_url(url: str) -> ConnectKwargs:
     if parsed.password:
         kwargs["password"] = unquote(parsed.password)
 
-    # We only support valkey://, valkeys:// and unix:// schemes.
+    # We only support valkey://, valkeys://, redis://, rediss://, and unix:// schemes.
     if parsed.scheme == "unix":
         if parsed.path:
             kwargs["path"] = unquote(parsed.path)
         kwargs["connection_class"] = UnixDomainSocketConnection
 
-    elif parsed.scheme in ("valkey", "valkeys"):
+    elif parsed.scheme in ("valkey", "valkeys", "redis", "rediss"):
         if parsed.hostname:
             kwargs["host"] = unquote(parsed.hostname)
         if parsed.port:
@@ -1063,13 +1077,9 @@ def parse_url(url: str) -> ConnectKwargs:
             except (AttributeError, ValueError):
                 pass
 
-        if parsed.scheme == "valkeys":
+        if parsed.scheme in ("valkeys", "rediss"):
             kwargs["connection_class"] = SSLConnection
-    else:
-        valid_schemes = "valkey://, valkeys://, unix://"
-        raise ValueError(
-            f"Valkey URL must specify one of the following schemes ({valid_schemes})"
-        )
+
 
     return kwargs
 

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -1023,20 +1023,6 @@ class ConnectKwargs(TypedDict, total=False):
 
 
 def parse_url(url: str) -> ConnectKwargs:
-    valid_schemes = (
-        "valkey://",
-        "valkeys://",
-        "redis://",
-        "rediss://",
-        "unix://",
-    )
-
-    if not any([url.startswith(scheme) for scheme in valid_schemes]):
-        raise ValueError(
-            "Valkey URL must specify one of the following "
-            f"schemes ({', '.join(valid_schemes)})"
-        )
-
     parsed: ParseResult = urlparse(url)
     kwargs: ConnectKwargs = {}
 

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -971,14 +971,18 @@ URL_QUERY_ARGUMENT_PARSERS = {
 
 
 def parse_url(url):
-    if not (
-        url.startswith("valkey://")
-        or url.startswith("valkeys://")
-        or url.startswith("unix://")
-    ):
+    valid_schemes = (
+        "valkey://",
+        "valkeys://",
+        "redis://",
+        "rediss://",
+        "unix://",
+    )
+    
+    if not any([url.startswith(scheme) for scheme in valid_schemes]):
         raise ValueError(
             "Valkey URL must specify one of the following "
-            "schemes (valkey://, valkeys://, unix://)"
+            f"schemes ({', '.join(valid_schemes)})"
         )
 
     url = urlparse(url)
@@ -1001,13 +1005,13 @@ def parse_url(url):
     if url.password:
         kwargs["password"] = unquote(url.password)
 
-    # We only support valkey://, valkeys:// and unix:// schemes.
+    # We only support valkey://, valkeys://, redis://, rediss://, and unix:// schemes.
     if url.scheme == "unix":
         if url.path:
             kwargs["path"] = unquote(url.path)
         kwargs["connection_class"] = UnixDomainSocketConnection
 
-    else:  # implied:  url.scheme in ("valkey", "valkeys"):
+    else:  # implied:  url.scheme in ("valkey", "valkeys", "redis", "rediss"):
         if url.hostname:
             kwargs["host"] = unquote(url.hostname)
         if url.port:
@@ -1021,7 +1025,7 @@ def parse_url(url):
             except (AttributeError, ValueError):
                 pass
 
-        if url.scheme == "valkeys":
+        if url.scheme in ("valkeys", "rediss"):
             kwargs["connection_class"] = SSLConnection
 
     return kwargs
@@ -1050,12 +1054,14 @@ class ConnectionPool:
 
             valkey://[[username]:[password]]@localhost:6379/0
             valkeys://[[username]:[password]]@localhost:6379/0
+            redis://[[username]:[password]]@localhost:6379/0
+            rediss://[[username]:[password]]@localhost:6379/0
             unix://[username@]/path/to/socket.sock?db=0[&password=password]
 
         Three URL schemes are supported:
 
-        - `valkey://` creates a TCP socket connection.
-        - `valkeys://` creates a SSL wrapped TCP socket connection.
+        - `valkey://` and `redis://` creates a TCP socket connection.
+        - `valkeys://` and `rediss://` creates a SSL wrapped TCP socket connection.
         - ``unix://``: creates a Unix Domain Socket connection.
 
         The username, password, hostname, path and all querystring values
@@ -1066,7 +1072,7 @@ class ConnectionPool:
         found will be used:
 
             1. A ``db`` querystring option, e.g. valkey://localhost?db=0
-            2. If using the valkey:// or valkeys:// schemes, the path argument
+            2. If using the valkey://, valkeys://, redis://, or rediss:// schemes, the path argument
                of the url, e.g. valkey://localhost/0
             3. A ``db`` keyword argument to this function.
 

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -971,19 +971,6 @@ URL_QUERY_ARGUMENT_PARSERS = {
 
 
 def parse_url(url):
-    valid_schemes = (
-        "valkey://",
-        "valkeys://",
-        "redis://",
-        "rediss://",
-        "unix://",
-    )
-
-    if not any([url.startswith(scheme) for scheme in valid_schemes]):
-        raise ValueError(
-            "Valkey URL must specify one of the following "
-            f"schemes ({', '.join(valid_schemes)})"
-        )
 
     url = urlparse(url)
     kwargs = {}

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -978,7 +978,7 @@ def parse_url(url):
         "rediss://",
         "unix://",
     )
-    
+
     if not any([url.startswith(scheme) for scheme in valid_schemes]):
         raise ValueError(
             "Valkey URL must specify one of the following "


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Do tests and lints pass with this change?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?
- [X] Was the change added to CHANGES file?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

- Adds 'redis://' and 'rediss://' to the list of accepted protocols for both sync and async connection pools
- Updates tests to use parameterization so that tests for valkey:// and valkeys:// also test redis// and rediss://

resolves #26 #23 
