### PR TITLE
updates async test to skip if SSL not installed

### DIFF
--- a/tests/test_asyncio/test_connection_pool.py
+++ b/tests/test_asyncio/test_connection_pool.py
@@ -7,6 +7,8 @@ import valkey.asyncio as valkey
 from tests.conftest import skip_if_server_version_lt
 from valkey._parsers.url_parser import to_bool
 from valkey.asyncio.connection import Connection
+from valkey.utils import SSL_AVAILABLE
+
 
 from .compat import aclosing, mock
 from .conftest import asynccontextmanager
@@ -541,7 +543,7 @@ class TestConnectionPoolUnixSocketURLParsing:
         assert pool.connection_class == valkey.UnixDomainSocketConnection
         assert pool.connection_kwargs == {"path": "/socket", "a": "1", "b": "2"}
 
-
+@pytest.mark.skipif(not SSL_AVAILABLE, reason="SSL not installed")
 class TestSSLConnectionURLParsing:
     def test_host(self):
         pool = valkey.ConnectionPool.from_url("valkeys://my.host")


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?


_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

Creates parity in testing on the sync/async tests of the connection pool by skipping the ssl tests if ssl is not installed on the async tests.

Resolves #26