### PR TITLE
Deprecate PyPy 3.8 in favor of 3.10

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -57,7 +57,7 @@ jobs:
        max-parallel: 15
        fail-fast: false
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
+         python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.9', 'pypy-3.10']
          test-type: ['standalone', 'cluster']
          connection-type: ['hiredis', 'plain']
      env:
@@ -185,7 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.9', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Close #12

### Description of change

PyPy does not support 3.8 anymore. Stop using it in CI and start using 3.10.
