### PR TITLE
Enable uvloop tests for "run-tests" job in CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -80,7 +80,9 @@ jobs:
            invoke devenv
            sleep 10 # time to settle
            invoke ${{matrix.test-type}}-tests
-           invoke ${{matrix.test-type}}-tests --uvloop
+           if [[ "${{matrix.python-version}}" != pypy-* ]]; then
+            invoke ${{matrix.test-type}}-tests --uvloop
+           fi
 
        - uses: actions/upload-artifact@v4
          if: success() || failure()

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
         test-type: ['standalone', 'cluster']
         connection-type: ['hiredis', 'plain']
         exclude:
@@ -140,7 +140,9 @@ jobs:
           invoke devenv
           sleep 10 # time to settle
           invoke ${{matrix.test-type}}-tests --protocol=3
-          invoke ${{matrix.test-type}}-tests --uvloop --protocol=3
+          if [[ "${{matrix.python-version}}" != pypy-* ]]; then
+            invoke ${{matrix.test-type}}-tests --uvloop --protocol=3
+          fi
 
       - uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -80,6 +80,7 @@ jobs:
            invoke devenv
            sleep 10 # time to settle
            invoke ${{matrix.test-type}}-tests
+           invoke ${{matrix.test-type}}-tests --uvloop
 
        - uses: actions/upload-artifact@v4
          if: success() || failure()


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change
This PR enables uvloop tests for the 'run-tests' job, as it is for RESP3 tests. This would resolve #45.
