### PR TITLE
Depend on hiredis < 3.0.0

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -75,7 +75,7 @@ jobs:
            pip install -r requirements.txt
            pip install -r dev_requirements.txt
            if [ "${{matrix.connection-type}}" == "hiredis" ]; then
-            pip install hiredis
+            pip install "hiredis<3.0.0"
            fi
            invoke devenv
            sleep 10 # time to settle
@@ -123,7 +123,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r dev_requirements.txt
           if [ "${{matrix.connection-type}}" == "hiredis" ]; then
-            pip install hiredis
+            pip install "hiredis<3.0.0"
           fi
           invoke devenv
           sleep 10 # time to settle

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     extras_require={
-        "hiredis": ["hiredis>=1.0.0"],
+        "hiredis": ["hiredis >=1.0.0, <3.0.0"],
         "ocsp": ["cryptography>=36.0.1", "pyopenssl==20.0.1", "requests>=2.26.0"],
     },
 )


### PR DESCRIPTION
### Description of change

hiredis 3.0.0 breaks compatibility with valkey-py.
This is just a temporary fix until #32 is ready.
