### PR TITLE
Fix RESP3 CI

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -105,9 +105,6 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
         test-type: ['standalone', 'cluster']
         connection-type: ['libvalkey', 'plain']
-        exclude:
-          - test-type: 'cluster'
-            connection-type: 'libvalkey'
     env:
        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     name: RESP3 [${{ matrix.python-version }} ${{matrix.test-type}}-${{matrix.connection-type}}]


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

This PR changes the RESP3 CI tests to run on the same python versions as the other tests. It also removed exclusions that were previously there. It would resolve https://github.com/valkey-io/valkey-py/issues/44
