### PR TITLE
github: replace call for sleep with wait-for-it.sh

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -79,7 +79,11 @@ jobs:
             pip install "libvalkey>=4.0.0"
            fi
            invoke devenv
-           sleep 10 # time to settle
+           if [[ "${{matrix.test-type}}" == "standalone" ]]; then
+            ./util/wait-for-it.sh localhost:6379
+           else
+            ./util/wait-for-it.sh localhost:16379
+           fi
            invoke ${{matrix.test-type}}-tests --protocol=${{ matrix.protocol-version }}
            if [[ "${{matrix.python-version}}" != pypy-* ]]; then
             invoke ${{matrix.test-type}}-tests --uvloop --protocol=${{ matrix.protocol-version }}

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -1648,7 +1648,10 @@ class NodesManager:
         self.nodes_cache = tmp_nodes_cache
         self.slots_cache = tmp_slots
         # Set the default node
-        self.default_node = self.get_nodes_by_server_type(PRIMARY)[0]
+        try:
+            self.default_node = self.get_nodes_by_server_type(PRIMARY)[0]
+        except IndexError:
+            raise ValkeyClusterException("No primary nodes found in the cluster")
         if self._dynamic_startup_nodes:
             # Populate the startup nodes with all discovered nodes
             self.startup_nodes = tmp_nodes_cache


### PR DESCRIPTION
Previously integration tests invoked `sleep 10` to "give time to settle" the environment. In a fast container, waiting for so long is not needed and in a slow one it might not be enough.

This commit changes this line to use `./util/wait-for-it.sh` instead [1] to check robustly that the port is being listened to.

Fixes #49.

[1] https://github.com/vishnubob/wait-for-it

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
