### PR TITLE
ci: cache docker layers and avoid re-downloading them for each job

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -50,8 +50,29 @@ jobs:
            pip install -r dev_requirements.txt
            invoke linters
 
+   populate-cache:
+     runs-on: ubuntu-latest
+     timeout-minutes: 60
+     name: Update docker cache
+     steps:
+       - uses: actions/checkout@v4
+       - name: Cache docker images
+         id: custom-cache
+         uses: actions/cache@v3
+         with:
+           path: ./custom-cache/
+           key: custom-cache
+       - if: ${{ steps.custom-cache.outputs.cache-hit != 'true' || github.event_name == 'schedule' }}
+         name: Update Cache
+         run: |
+           mkdir -p ./custom-cache/
+           docker compose --profile all build
+           docker pull valkey/valkey:latest
+           docker save valkey-py-stunnel:latest valkey-py-cluster:latest valkey/valkey:latest -o ./custom-cache/all.tar
+
    run-tests:
      runs-on: ubuntu-latest
+     needs: [populate-cache]
      timeout-minutes: 60
      strategy:
        max-parallel: 15
@@ -70,6 +91,17 @@ jobs:
          with:
            python-version: ${{ matrix.python-version }}
            cache: 'pip'
+
+       - name: Cache docker images
+         id: custom-cache
+         uses: actions/cache@v3
+         with:
+           path: ./custom-cache/
+           fail-on-cache-miss: true
+           key: custom-cache
+       - name: Use Cache
+         run: docker image load -i ./custom-cache/all.tar
+
        - name: run tests
          run: |
            pip install -U setuptools wheel
@@ -115,6 +147,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.9
+
+      - name: Cache docker images
+        id: custom-cache
+        uses: actions/cache@v3
+        with:
+          path: ./custom-cache/
+          fail-on-cache-miss: true
+          key: custom-cache
+      - name: Use Cache
+        run: docker image load -i ./custom-cache/all.tar
+
       - name: Run installed unit tests
         run: |
           bash .github/workflows/install_and_test.sh ${{ matrix.extension }}


### PR DESCRIPTION
### Description of change
 
Sometimes the CI fails because Docker doesn't respond.
It could be because we download many docker images in every job and we have 58 jobs now.
With this commit, the image layers will be downloaded during nightly builds and cached.
