### PR TITLE
update python version constraint to < 3.11 for async-timeout requirement 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-async-timeout>=4.0.3
+async-timeout>=4.0.3; python_version<"3.11"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="valkey-py@lists.valkey.io",
     python_requires=">=3.8",
     install_requires=[
-        'async-timeout>=4.0.3; python_version<="3.12"',
+        'async-timeout>=4.0.3; python_version<"3.11"',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
async-timeout library has effectively been upstreamed into Python 3.11+. installing it for python >= 3.11 should not be necessary.

this will enable packaging valkey-py for fedora 39, which comes with python 3.12 and does not conatin async-timeout 4.0.3 package.

see the deprecation notice:
https://github.com/aio-libs/async-timeout?tab=readme-ov-file#deprecated

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
