### PR TITLE
Make valkey-py install the correct dependencies in Python 3.11.0 to Python 3.11.3

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -78,7 +78,7 @@ jobs:
        max-parallel: 15
        fail-fast: false
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.8', '3.9', '3.10', '3.11', '3.11.1', '3.12', 'pypy-3.9', 'pypy-3.10']
          test-type: ['standalone', 'cluster']
          connection-type: ['libvalkey', 'plain']
          protocol-version: ['2','3']
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.11.1', '3.12', 'pypy-3.9', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-async-timeout>=4.0.3; python_version<"3.11"
+async-timeout>=4.0.3; python_version<"3.11.3"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="valkey-py@lists.valkey.io",
     python_requires=">=3.8",
     install_requires=[
-        'async-timeout>=4.0.3; python_version<"3.11"',
+        'async-timeout>=4.0.3; python_version<"3.11.3"',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/valkey/_parsers/base.py
+++ b/valkey/_parsers/base.py
@@ -3,7 +3,7 @@ from abc import ABC
 from asyncio import IncompleteReadError, StreamReader, TimeoutError
 from typing import List, Optional, Union
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
+if sys.version_info >= (3, 11, 3):
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout

--- a/valkey/_parsers/libvalkey.py
+++ b/valkey/_parsers/libvalkey.py
@@ -3,7 +3,7 @@ import socket
 import sys
 from typing import Callable, List, Optional, TypedDict, Union
 
-if sys.version_info.major >= 3 and sys.version_info.minor >= 11:
+if sys.version_info >= (3, 11, 3):
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout


### PR DESCRIPTION
I just happened to be using Python 3.11.1 while using valkey-py. 

The PR #87 broke my CI/CD pipeline (when upgrading to valkey-py `6.1` bc the codebase, in https://github.com/valkey-io/valkey-py/blob/03320e6b2720a90d1b2ac7946d82bdc4d87f3faa/valkey/asyncio/connection.py#L31 

just so happens to check whether or not we're 3.11.3 and above.

If you are in Python 3.11.0 - 3.11.2, you go into the else and this code fails if async timeout is not installed

so we need to still to install `async-timeout` if python version < 3.11.3

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
