### PR TITLE
drop compose format and commands v1, use supported v2+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Here's how to get started with your code contribution:
         c.  pip install -r dev_requirements.txt
         c.  pip install -r requirements.txt
 
-4.  If you need a development environment, run `invoke devenv`. Note: this relies on docker-compose to build environments, and assumes that you have a version supporting [docker profiles](https://docs.docker.com/compose/profiles/).
+4.  If you need a development environment, run `invoke devenv`. Note: this relies on docker compose to build environments, and assumes that you have a version supporting [docker profiles](https://docs.docker.com/compose/profiles/).
 5.  While developing, make sure the tests pass by running `invoke tests`
 6.  If you like the change and think the project could use it, send a
     pull request

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,5 @@
 ---
 
-version: "3.8"
-
 services:
 
   valkey:

--- a/docs/examples/opentelemetry/README.md
+++ b/docs/examples/opentelemetry/README.md
@@ -30,8 +30,8 @@ pip install -r requirements.txt
 **Step 4**. Start the services using Docker and make sure Uptrace is running:
 
 ```shell
-docker-compose up -d
-docker-compose logs uptrace
+docker compose up -d
+docker compose logs uptrace
 ```
 
 **Step 5**. Run the Valkey client example and follow the link from the CLI to view the trace:

--- a/docs/examples/opentelemetry/compose.yaml
+++ b/docs/examples/opentelemetry/compose.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   clickhouse:
     image: clickhouse/clickhouse-server:22.7


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
I propose to abandon support for compose v1. development from v2+