### PR TITLE
Revert "Temporarily fix https://github.com/actions/runner-images/issu…"

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,7 +27,7 @@ jobs:
 
    dependency-audit:
      name: Dependency audit
-     runs-on: ubuntu-22.04
+     runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v4
        - uses: pypa/gh-action-pip-audit@v1.1.0


### PR DESCRIPTION
### Description of change

The workaround in 318019a1326ed69696627edd51db80d7a2840afd is no longer necessary, since the issue has been fixed by GH.
We should keep an eye on what happen in https://github.com/actions/runner-images/issues/10636 as this (or a similar) issue could come back.
For now, just revert 318019a1326ed69696627edd51db80d7a2840afd.