### PR TITLE
Set socket_timeout default value to 5 seconds

### DIFF
--- a/valkey/asyncio/client.py
+++ b/valkey/asyncio/client.py
@@ -205,7 +205,7 @@ class Valkey(
         port: int = 6379,
         db: Union[str, int] = 0,
         password: Optional[str] = None,
-        socket_timeout: Optional[float] = None,
+        socket_timeout: Optional[float] = 5,
         socket_connect_timeout: Optional[float] = None,
         socket_keepalive: Optional[bool] = None,
         socket_keepalive_options: Optional[Mapping[int, Union[int, bytes]]] = None,

--- a/valkey/asyncio/cluster.py
+++ b/valkey/asyncio/cluster.py
@@ -259,7 +259,7 @@ class ValkeyCluster(AbstractValkey, AbstractValkeyCluster, AsyncValkeyClusterCom
         socket_connect_timeout: Optional[float] = None,
         socket_keepalive: bool = False,
         socket_keepalive_options: Optional[Mapping[int, Union[int, bytes]]] = None,
-        socket_timeout: Optional[float] = None,
+        socket_timeout: Optional[float] = 5,
         retry: Optional["Retry"] = None,
         retry_on_error: Optional[List[Type[Exception]]] = None,
         # SSL related kwargs

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -136,7 +136,7 @@ class AbstractConnection:
         *,
         db: Union[str, int] = 0,
         password: Optional[str] = None,
-        socket_timeout: Optional[float] = None,
+        socket_timeout: Optional[float] = 5,
         socket_connect_timeout: Optional[float] = None,
         retry_on_timeout: bool = False,
         retry_on_error: Union[list, _Sentinel] = SENTINEL,

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -137,7 +137,7 @@ class AbstractConnection:
         self,
         db: int = 0,
         password: Optional[str] = None,
-        socket_timeout: Optional[float] = None,
+        socket_timeout: Optional[float] = 5,
         socket_connect_timeout: Optional[float] = None,
         retry_on_timeout: bool = False,
         retry_on_error=SENTINEL,


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey-py/issues/119

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

Setting a default timeout value for TCP connections to avoid the process hanging forever on a TCP connection in `SYN_SENT`.