### PR TITLE
Issue 131: Fixes Flaky test by increasing timeout to 1s

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5096,7 +5096,7 @@ class TestValkeyCommands:
 
         thread = threading.Thread(target=helper)
         thread.start()
-        thread.join(0.1)
+        thread.join(1)
         try:
             assert not thread.is_alive()
             assert ok


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

The thread's join has a timeout that is too short (0.1) and sometimes the test fails, so I'm Increasing it to 1 second to avoid failing.
