### PR TITLE
fixed type hint of hrandfield method

### DIFF
--- a/valkey/commands/core.py
+++ b/valkey/commands/core.py
@@ -2153,7 +2153,7 @@ class BasicKeyCommands(CommandsProtocol):
 
     def hrandfield(
         self, key: str, count: int = None, withvalues: bool = False
-    ) -> ResponseT:
+    ) -> Union[bytes, List[bytes], None]:
         """
         Return a random field from the hash value stored at key.
 


### PR DESCRIPTION
hrandfield returns a byte if no count is given
if count is given it returns a list of bytes
if there is no value found, it returns None