### PR TITLE
Fix AttributeError on closing of django runserver

### DIFF
--- a/valkey/client.py
+++ b/valkey/client.py
@@ -518,7 +518,15 @@ class Valkey(ValkeyModuleCommands, CoreCommands, SentinelCommands):
         self.close()
 
     def __del__(self):
-        self.close()
+        try:
+            self.close()
+        except AttributeError as exc:
+            if exc.name in ("getpid", "Lock"):
+                # Fixes AttributeError: 
+                # 'NoneType' object has no attribute 'getpid'
+                pass
+            else:
+                raise
 
     def close(self):
         # In case a connection property does not yet exist


### PR DESCRIPTION
When closing Django runserver, valkey client consistently throws the AttributeError in the function __del__

This patch fixes that problem

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
