### PR TITLE
Revert some typing commits

### DIFF
--- a/valkey/commands/core.py
+++ b/valkey/commands/core.py
@@ -8,7 +8,6 @@ from typing import (
     AsyncIterator,
     Awaitable,
     Callable,
-    Dict,
     Iterable,
     Iterator,
     List,

--- a/valkey/commands/core.py
+++ b/valkey/commands/core.py
@@ -2153,7 +2153,7 @@ class BasicKeyCommands(CommandsProtocol):
 
     def hrandfield(
         self, key: str, count: int = None, withvalues: bool = False
-    ) -> Union[bytes, List[bytes], None]:
+    ) -> ResponseT:
         """
         Return a random field from the hash value stored at key.
 

--- a/valkey/commands/core.py
+++ b/valkey/commands/core.py
@@ -2995,7 +2995,7 @@ class ScanCommands(CommandsProtocol):
         count: Union[int, None] = None,
         _type: Union[str, None] = None,
         **kwargs,
-    ) -> Tuple[int, List[bytes]]:
+    ) -> ResponseT:
         """
         Incrementally return lists of key names. Also return a cursor
         indicating the scan position.
@@ -3055,7 +3055,7 @@ class ScanCommands(CommandsProtocol):
         cursor: int = 0,
         match: Union[PatternT, None] = None,
         count: Union[int, None] = None,
-    ) -> Tuple[int, List[bytes]]:
+    ) -> ResponseT:
         """
         Incrementally return lists of elements in a set. Also return a cursor
         indicating the scan position.
@@ -3099,7 +3099,7 @@ class ScanCommands(CommandsProtocol):
         match: Union[PatternT, None] = None,
         count: Union[int, None] = None,
         no_values: Union[bool, None] = None,
-    ) -> Tuple[int, Dict[bytes, bytes]]:
+    ) -> ResponseT:
         """
         Incrementally return key/value slices in a hash. Also return a cursor
         indicating the scan position.
@@ -3155,7 +3155,7 @@ class ScanCommands(CommandsProtocol):
         match: Union[PatternT, None] = None,
         count: Union[int, None] = None,
         score_cast_func: Union[type, Callable] = float,
-    ) -> Tuple[int, List[Tuple[bytes, float]]]:
+    ) -> ResponseT:
         """
         Incrementally return lists of elements in a sorted set. Also return a
         cursor indicating the scan position.

--- a/valkey/commands/core.py
+++ b/valkey/commands/core.py
@@ -4944,7 +4944,7 @@ class HashCommands(CommandsProtocol):
     see: https://valkey.io/topics/data-types-intro#valkey-hashes
     """
 
-    def hdel(self, name: str, *keys: str) -> int:
+    def hdel(self, name: str, *keys: str) -> Union[Awaitable[int], int]:
         """
         Delete ``keys`` from hash ``name``
 
@@ -4952,7 +4952,7 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HDEL", name, *keys)
 
-    def hexists(self, name: str, key: str) -> bool:
+    def hexists(self, name: str, key: str) -> Union[Awaitable[bool], bool]:
         """
         Returns a boolean indicating if ``key`` exists within hash ``name``
 
@@ -4960,7 +4960,9 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HEXISTS", name, key, keys=[name])
 
-    def hget(self, name: str, key: str) -> Optional[bytes]:
+    def hget(
+        self, name: str, key: str
+    ) -> Union[Awaitable[Optional[str]], Optional[str]]:
         """
         Return the value of ``key`` within the hash ``name``
 
@@ -4968,7 +4970,7 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HGET", name, key, keys=[name])
 
-    def hgetall(self, name: str) -> dict:
+    def hgetall(self, name: str) -> Union[Awaitable[dict], dict]:
         """
         Return a Python dict of the hash's name/value pairs
 
@@ -4976,7 +4978,9 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HGETALL", name, keys=[name])
 
-    def hincrby(self, name: str, key: str, amount: int = 1) -> int:
+    def hincrby(
+        self, name: str, key: str, amount: int = 1
+    ) -> Union[Awaitable[int], int]:
         """
         Increment the value of ``key`` in hash ``name`` by ``amount``
 
@@ -4984,7 +4988,9 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HINCRBY", name, key, amount)
 
-    def hincrbyfloat(self, name: str, key: str, amount: float = 1.0) -> float:
+    def hincrbyfloat(
+        self, name: str, key: str, amount: float = 1.0
+    ) -> Union[Awaitable[float], float]:
         """
         Increment the value of ``key`` in hash ``name`` by floating ``amount``
 
@@ -4992,7 +4998,7 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HINCRBYFLOAT", name, key, amount)
 
-    def hkeys(self, name: str) -> List[bytes]:
+    def hkeys(self, name: str) -> Union[Awaitable[List], List]:
         """
         Return the list of keys within hash ``name``
 
@@ -5000,7 +5006,7 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HKEYS", name, keys=[name])
 
-    def hlen(self, name: str) -> int:
+    def hlen(self, name: str) -> Union[Awaitable[int], int]:
         """
         Return the number of elements in hash ``name``
 
@@ -5015,7 +5021,7 @@ class HashCommands(CommandsProtocol):
         value: Optional[str] = None,
         mapping: Optional[dict] = None,
         items: Optional[list] = None,
-    ) -> int:
+    ) -> Union[Awaitable[int], int]:
         """
         Set ``key`` to ``value`` within hash ``name``,
         ``mapping`` accepts a dict of key/value pairs that will be
@@ -5039,7 +5045,7 @@ class HashCommands(CommandsProtocol):
 
         return self.execute_command("HSET", name, *pieces)
 
-    def hsetnx(self, name: str, key: str, value: str) -> int:
+    def hsetnx(self, name: str, key: str, value: str) -> Union[Awaitable[bool], bool]:
         """
         Set ``key`` to ``value`` within hash ``name`` if ``key`` does not
         exist.  Returns 1 if HSETNX created a field, otherwise 0.
@@ -5048,7 +5054,7 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HSETNX", name, key, value)
 
-    def hmset(self, name: str, mapping: dict) -> bool:
+    def hmset(self, name: str, mapping: dict) -> Union[Awaitable[str], str]:
         """
         Set key to value within hash ``name`` for each corresponding
         key and value from the ``mapping`` dict.
@@ -5068,7 +5074,7 @@ class HashCommands(CommandsProtocol):
             items.extend(pair)
         return self.execute_command("HMSET", name, *items)
 
-    def hmget(self, name: str, keys: List, *args: List) -> List[bytes]:
+    def hmget(self, name: str, keys: List, *args: List) -> Union[Awaitable[List], List]:
         """
         Returns a list of values ordered identically to ``keys``
 
@@ -5077,7 +5083,7 @@ class HashCommands(CommandsProtocol):
         args = list_or_args(keys, args)
         return self.execute_command("HMGET", name, *args, keys=[name])
 
-    def hvals(self, name: str) -> List[bytes]:
+    def hvals(self, name: str) -> Union[Awaitable[List], List]:
         """
         Return the list of values within hash ``name``
 
@@ -5085,7 +5091,7 @@ class HashCommands(CommandsProtocol):
         """
         return self.execute_command("HVALS", name, keys=[name])
 
-    def hstrlen(self, name: str, key: str) -> int:
+    def hstrlen(self, name: str, key: str) -> Union[Awaitable[int], int]:
         """
         Return the number of bytes stored in the value of ``key``
         within hash ``name``


### PR DESCRIPTION
Issue #162 revealed that the issues with typing in valkey-py are quite a bit deeper and require some rework of internal classes. The changes introduced in those commits turned out to not fix anything.

At this point we need to publish the new beta because of accumulated fixes since 6.1.0b1. The typing system fixes will be introduced later.

Closes #162 

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
