### PR TITLE
Handle closing connection when event loop is closed

### DIFF
--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -247,8 +247,12 @@ class AbstractConnection:
         Internal method to silently close the connection without waiting
         """
         if self._writer:
-            self._writer.close()
-            self._writer = self._reader = None
+            try:
+                self._writer.close()
+                self._writer = self._reader = None
+            # raised if the event loop is already closed
+            except RuntimeError:  # noqa
+                pass
 
     def __repr__(self):
         repr_args = ",".join((f"{k}={v}" for k, v in self.repr_pieces()))


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] ~~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~~
- [ ] ~~Is there an example added to the examples folder (if applicable)?~~

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

Improve the connection cleanup logic in `AbstractConnection` by adding a try-except block around the .close() call on the writer to protect against scenarios where the event loop is already closed.

Given an example use case:

```python
import asyncio
import valkey.asyncio

client = valkey.asyncio.Redis.from_url("redis://localhost:7379")
asyncio.run(client.ping())
```

The following traceback is noted after the process exists:
```
Exception ignored in: <function AbstractConnection.__del__ at 0x10519e340>
Traceback (most recent call last):
  File "<...>/valkey-py/valkey/asyncio/connection.py", line 243, in __del__
  File "<...>/valkey-py/valkey/asyncio/connection.py", line 250, in _close
  File "<...>/python/3.12.0/lib/python3.12/asyncio/streams.py", line 343, in close
  File "<...>/python/3.12.0/lib/python3.12/asyncio/selector_events.py", line 1206, in close
  File "<...>/python/3.12.0/lib/python3.12/asyncio/selector_events.py", line 871, in close
  File "<...>/python/3.12.0/lib/python3.12/asyncio/base_events.py", line 772, in call_soon
  File "<...>/python/3.12.0/lib/python3.12/asyncio/base_events.py", line 519, in _check_closed
RuntimeError: Event loop is closed
```
