### PR TITLE
fix: prevent RuntimeError in `asyncio.cluster.NodesManager.initialize()`

### DIFF
--- a/valkey/asyncio/cluster.py
+++ b/valkey/asyncio/cluster.py
@@ -1288,7 +1288,7 @@ class NodesManager:
         startup_nodes_reachable = False
         fully_covered = False
         exception = None
-        for startup_node in self.startup_nodes.values():
+        for startup_node in tuple(self.startup_nodes.values()):
             try:
                 # Make sure cluster mode is enabled on this node
                 try:


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

The change prevents `RuntimeError` being raised when `valkey.asyncio.cluster.NodeManager.startup_nodes` are modified while performing `.initialize()`.

Fixes #181 