### PR TITLE
Drop support for Python 3.8 and disable tests broken in 8.1.0..8.1.1

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,7 +89,7 @@ jobs:
        max-parallel: 15
        fail-fast: false
        matrix:
-         python-version: ['3.8', '3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
          test-type: ['standalone', 'cluster']
          connection-type: ['libvalkey', 'plain']
          protocol-version: ['2','3']
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     author="valkey-py authors",
     author_email="valkey-py@lists.valkey.io",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         'async-timeout>=4.0.3; python_version<"3.11.3"',
     ],
@@ -47,7 +47,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import argparse
 import math
 import time
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 from unittest import mock
 from unittest.mock import Mock
 from urllib.parse import urlparse
@@ -173,13 +174,12 @@ def pytest_sessionstart(session):
 
 
 def wait_for_cluster_creation(valkey_url, cluster_nodes, timeout=60):
-    """
-    Waits for the cluster creation to complete.
+    """Waits for the cluster creation to complete.
     As soon as all :cluster_nodes: nodes become available, the cluster will be
     considered ready.
     :param valkey_url: the cluster's url, e.g. valkey://localhost:16379/0
     :param cluster_nodes: The number of nodes in the cluster
-    :param timeout: the amount of time to wait (in seconds)
+    :param timeout: the amount of time to wait (in seconds).
     """
     now = time.time()
     end_time = now + timeout
@@ -213,6 +213,14 @@ def skip_if_server_version_gte(min_version: str) -> _TestDecorator:
     valkey_version = VALKEY_INFO.get("version", "0")
     check = Version(valkey_version) >= Version(min_version)
     return pytest.mark.skipif(check, reason=f"Valkey version required < {min_version}")
+
+
+def skip_if_version_is_one_of(versions: list[str]) -> _TestDecorator:
+    valkey_version = VALKEY_INFO.get("version", "0")
+    check = Version(valkey_version) in [Version(v) for v in versions]
+    return pytest.mark.skipif(
+        check, reason=f"Valkey version required not in {versions}"
+    )
 
 
 def skip_unless_arch_bits(arch_bits: int) -> _TestDecorator:
@@ -263,8 +271,7 @@ def skip_if_cryptography() -> _TestDecorator:
 def _get_client(
     cls, request, single_connection_client=True, flushdb=True, from_url=None, **kwargs
 ):
-    """
-    Helper for fixtures or tests that need a Valkey client
+    """Helper for fixtures or tests that need a Valkey client.
 
     Uses the "--valkey-url" command line argument for connection info. Unlike
     ConnectionPool.from_url, keyword arguments to this function override
@@ -320,38 +327,38 @@ def cluster_teardown(client, flushdb):
     client.disconnect_connection_pools()
 
 
-@pytest.fixture()
+@pytest.fixture
 def r(request):
     with _get_client(valkey.Valkey, request) as client:
         yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def decoded_r(request):
     with _get_client(valkey.Valkey, request, decode_responses=True) as client:
         yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def r_timeout(request):
     with _get_client(valkey.Valkey, request, socket_timeout=1) as client:
         yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def r2(request):
-    "A second client for tests that need multiple"
+    """A second client for tests that need multiple."""
     with _get_client(valkey.Valkey, request) as client:
         yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def sslclient(request):
     with _get_client(valkey.Valkey, request, ssl=True) as client:
         yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def sentinel_setup(local_cache, request):
     sentinel_ips = request.config.getoption("--sentinels")
     sentinel_endpoints = [
@@ -371,7 +378,7 @@ def sentinel_setup(local_cache, request):
         s.close()
 
 
-@pytest.fixture()
+@pytest.fixture
 def master(request, sentinel_setup):
     master_service = request.config.getoption("--master-service")
     master = sentinel_setup.master_for(master_service)
@@ -388,19 +395,19 @@ def _gen_cluster_mock_resp(r, response):
         yield r
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_cluster_resp_ok(request, **kwargs):
     r = _get_client(valkey.Valkey, request, **kwargs)
     yield from _gen_cluster_mock_resp(r, "OK")
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_cluster_resp_int(request, **kwargs):
     r = _get_client(valkey.Valkey, request, **kwargs)
     yield from _gen_cluster_mock_resp(r, 2)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_cluster_resp_info(request, **kwargs):
     r = _get_client(valkey.Valkey, request, **kwargs)
     response = (
@@ -414,7 +421,7 @@ def mock_cluster_resp_info(request, **kwargs):
     yield from _gen_cluster_mock_resp(r, response)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_cluster_resp_nodes(request, **kwargs):
     r = _get_client(valkey.Valkey, request, **kwargs)
     response = (
@@ -438,7 +445,7 @@ def mock_cluster_resp_nodes(request, **kwargs):
     yield from _gen_cluster_mock_resp(r, response)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_cluster_resp_slaves(request, **kwargs):
     r = _get_client(valkey.Valkey, request, **kwargs)
     response = (
@@ -456,7 +463,7 @@ def master_host(request):
     return parts.hostname, (parts.port or 6379)
 
 
-@pytest.fixture()
+@pytest.fixture
 def valkey_version():
     return Version(VALKEY_INFO["version"])
 
@@ -502,8 +509,7 @@ def assert_resp_response(r, response, resp2_expected, resp3_expected):
 
 
 def assert_geo_is_close(coords, expected_coords):
-    """
-    Verifies that the coordinates are close within the floating point tolerance
+    """Verifies that the coordinates are close within the floating point tolerance.
 
     Valkey uses 52-bit presicion
     """
@@ -512,7 +518,7 @@ def assert_geo_is_close(coords, expected_coords):
 
 
 def assert_resp_response_isclose(r, response, resp2_expected, resp3_expected):
-    """Verifies that the responses are close within the floating point tolerance"""
+    """Verifies that the responses are close within the floating point tolerance."""
     protocol = get_protocol_version(r)
 
     if protocol in [2, "2", None]:

--- a/tests/test_asyncio/test_monitor.py
+++ b/tests/test_asyncio/test_monitor.py
@@ -1,4 +1,5 @@
 import pytest
+from tests.conftest import skip_if_version_is_one_of
 
 from .conftest import wait_for_command
 
@@ -6,7 +7,7 @@ from .conftest import wait_for_command
 @pytest.mark.onlynoncluster
 class TestMonitor:
     async def test_wait_command_not_found(self, r):
-        """Make sure the wait_for_command func works when command is not found"""
+        """Make sure the wait_for_command func works when command is not found."""
         async with r.monitor() as m:
             response = await wait_for_command(r, m, "nothing")
             assert response is None
@@ -23,6 +24,9 @@ class TestMonitor:
             assert isinstance(response["client_port"], str)
             assert response["command"] == "PING"
 
+    # Escaping in MONITOR is broken in Valkey 8.1.0 and 8.1.1
+    # https://github.com/valkey-io/valkey/issues/2035
+    @skip_if_version_is_one_of(["8.1.0", "8.1.1"])
     async def test_command_with_quoted_key(self, r):
         async with r.monitor() as m:
             await r.get('foo"bar')
@@ -36,6 +40,9 @@ class TestMonitor:
             response = await wait_for_command(r, m, "GET foo\\x92")
             assert response["command"] == "GET foo\\x92"
 
+    # Escaping in MONITOR is broken in Valkey 8.1.0 and 8.1.1
+    # https://github.com/valkey-io/valkey/issues/2035
+    @skip_if_version_is_one_of(["8.1.0", "8.1.1"])
     async def test_command_with_escaped_data(self, r):
         async with r.monitor() as m:
             byte_string = b"foo\\x92"

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -989,9 +989,6 @@ class TestPubSubAutoReconnect:
 
 @pytest.mark.onlynoncluster
 class TestBaseException:
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="requires python 3.8 or higher"
-    )
     async def test_outer_timeout(self, r: valkey.Valkey):
         """
         Using asyncio_timeout manually outside the inner method timeouts works.
@@ -1023,9 +1020,6 @@ class TestBaseException:
         # the timeout on the read should not cause disconnect
         assert pubsub.connection.is_connected
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8), reason="requires python 3.8 or higher"
-    )
     async def test_base_exception(self, r: valkey.Valkey):
         """
         Manually trigger a BaseException inside the parser's .read_response method

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -47,6 +47,7 @@ from .conftest import (
     assert_resp_response,
     is_resp2_connection,
     skip_if_server_version_lt,
+    skip_if_version_is_one_of,
     skip_unless_arch_bits,
     wait_for_command,
 )
@@ -3381,6 +3382,9 @@ class TestClusterMonitor:
             assert isinstance(response["client_port"], str)
             assert response["command"] == "PING"
 
+    # Escaping in MONITOR is broken in Valkey 8.1.0 and 8.1.1
+    # https://github.com/valkey-io/valkey/issues/2035
+    @skip_if_version_is_one_of(["8.1.0", "8.1.1"])
     def test_command_with_quoted_key(self, r):
         key = "{foo}1"
         node = r.get_node_from_key(key)
@@ -3398,6 +3402,9 @@ class TestClusterMonitor:
             response = wait_for_command(r, m, "GET {foo}bar\\x92", key=key)
             assert response["command"] == "GET {foo}bar\\x92"
 
+    # Escaping in MONITOR is broken in Valkey 8.1.0 and 8.1.1
+    # https://github.com/valkey-io/valkey/issues/2035
+    @skip_if_version_is_one_of(["8.1.0", "8.1.1"])
     def test_command_with_escaped_data(self, r):
         key = "{foo}1"
         node = r.get_node_from_key(key)

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,12 +1,12 @@
 import pytest
 
-from .conftest import wait_for_command
+from .conftest import skip_if_version_is_one_of, wait_for_command
 
 
 @pytest.mark.onlynoncluster
 class TestMonitor:
     def test_wait_command_not_found(self, r):
-        "Make sure the wait_for_command func works when command is not found"
+        """Make sure the wait_for_command func works when command is not found."""
         with r.monitor() as m:
             response = wait_for_command(r, m, "nothing")
             assert response is None
@@ -23,6 +23,9 @@ class TestMonitor:
             assert isinstance(response["client_port"], str)
             assert response["command"] == "PING"
 
+    # Escaping in MONITOR is broken in Valkey 8.1.0 and 8.1.1
+    # https://github.com/valkey-io/valkey/issues/2035
+    @skip_if_version_is_one_of(["8.1.0", "8.1.1"])
     def test_command_with_quoted_key(self, r):
         with r.monitor() as m:
             r.get('foo"bar')
@@ -36,6 +39,9 @@ class TestMonitor:
             response = wait_for_command(r, m, "GET foo\\x92")
             assert response["command"] == "GET foo\\x92"
 
+    # Escaping in MONITOR is broken in Valkey 8.1.0 and 8.1.1
+    # https://github.com/valkey-io/valkey/issues/2035
+    @skip_if_version_is_one_of(["8.1.0", "8.1.1"])
     def test_command_with_escaped_data(self, r):
         with r.monitor() as m:
             byte_string = b"foo\\x92"


### PR DESCRIPTION
Some of MONITOR tests got broken due to a bug in the server: https://github.com/valkey-io/valkey/pull/2036

This commit disables those tests for these versions of Valkey server thus letting the CI proceed.

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
