### PR TITLE
tests: use `sorted(...)` instead of `.sort()`

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2620,7 +2620,7 @@ class TestNodesManager:
         ]
         startup_nodes = list(rc.nodes_manager.startup_nodes.keys())
         if dynamic_startup_nodes is True:
-            assert startup_nodes.sort() == discovered_nodes.sort()
+            assert sorted(startup_nodes) == sorted(discovered_nodes)
         else:
             assert startup_nodes == ["my@DNS.com:7000"]
 

--- a/tests/test_asyncio/test_search.py
+++ b/tests/test_asyncio/test_search.py
@@ -827,7 +827,7 @@ async def test_tags(decoded_r: valkey.Valkey):
         assert 1 == res.total
 
         q2 = await decoded_r.ft().tagvals("tags")
-        assert (tags.split(",") + tags2.split(",")).sort() == q2.sort()
+        assert sorted(tags.split(",") + tags2.split(",")) == sorted(q2)
     else:
         res = await decoded_r.ft().search(q)
         assert 1 == res["total_results"]

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2815,7 +2815,7 @@ class TestNodesManager:
         ]
         startup_nodes = list(rc.nodes_manager.startup_nodes.keys())
         if dynamic_startup_nodes is True:
-            assert startup_nodes.sort() == discovered_nodes.sort()
+            assert sorted(startup_nodes) == sorted(discovered_nodes)
         else:
             assert startup_nodes == ["my@DNS.com:7000"]
 


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [X] Do tests and lints pass with this change?
- [X] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

While doing #167, I just copied existing tests for the valkey cluster. After reading the test code again, I noticed that the code compares 
```py
assert some_list.sort() == other_list.sort()
```

This is inherently flawed, as `.sort()` returns `None`. You can verify that with `[0,1].sort() == [1,2].sort()`. 

This PR uses `sorted(...)` instead which actually returns the sorted list as intended. I also fix one other occurrence of this I found using `rg "sort\(\) =="`
