### PR TITLE
fix dependency `async-timeout` env marker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-async-timeout>=4.0.3; python_version<"3.11.3"
+async-timeout>=4.0.3; python_full_version<"3.11.3"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="valkey-py@lists.valkey.io",
     python_requires=">=3.9",
     install_requires=[
-        'async-timeout>=4.0.3; python_version<"3.11.3"',
+        'async-timeout>=4.0.3; python_full_version<"3.11.3"',
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

`python_version` is expected to contain only major and minor version of python,
so only `python_full_version<"3.11.3"` works as we expected. 

it works for `3.11` beacuase `'3.11' < '3.11.3'` is true


<!-- Please provide a description of the change here. -->
