### PR TITLE
Fix redis links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For more details, please see the documentation on [advanced topics page](https:/
 
 ### Pipelines
 
-The following is a basic example of a [Valkey pipeline](https://redis.io/docs/manual/pipelining/), a method to optimize round-trip calls, by batching Valkey commands, and receiving their results as a list.
+The following is a basic example of a [Valkey pipeline](https://valkey.io/topics/pipelining/), a method to optimize round-trip calls, by batching Valkey commands, and receiving their results as a list.
 
 
 ``` python
@@ -127,7 +127,7 @@ The following is a basic example of a [Valkey pipeline](https://redis.io/docs/ma
 
 ### PubSub
 
-The following example shows how to utilize [Valkey Pub/Sub](https://redis.io/docs/manual/pubsub/) to subscribe to specific channels.
+The following example shows how to utilize [Valkey Pub/Sub](https://valkey.io/topics/pubsub/) to subscribe to specific channels.
 
 ``` python
 >>> r = valkey.Valkey(...)


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] *N/A* Is there an example added to the examples folder (if applicable)?

### Description of change

Fixes old redis.io links in README.md, uses valkey doc instead.