### PR TITLE
connection: reintroduce parse_url as a function in valkey.connection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,8 @@ import pytest
 import valkey
 from packaging.version import Version
 from valkey import Sentinel
-from valkey._parsers import parse_url
 from valkey.backoff import NoBackoff
-from valkey.connection import Connection
+from valkey.connection import Connection, parse_url
 from valkey.exceptions import ValkeyClusterException
 from valkey.retry import Retry
 
@@ -286,7 +285,7 @@ def _get_client(
 
     cluster_mode = VALKEY_INFO["cluster_enabled"]
     if not cluster_mode:
-        url_options = parse_url(valkey_url, False)
+        url_options = parse_url(valkey_url)
         url_options.update(kwargs)
         pool = valkey.ConnectionPool(**url_options)
         client = cls(connection_pool=pool)

--- a/tests/test_asyncio/conftest.py
+++ b/tests/test_asyncio/conftest.py
@@ -5,10 +5,9 @@ import pytest
 import pytest_asyncio
 import valkey.asyncio as valkey
 from tests.conftest import VALKEY_INFO
-from valkey._parsers import parse_url
 from valkey.asyncio import Sentinel
 from valkey.asyncio.client import Monitor
-from valkey.asyncio.connection import Connection
+from valkey.asyncio.connection import Connection, parse_url
 from valkey.asyncio.retry import Retry
 from valkey.backoff import NoBackoff
 
@@ -55,7 +54,7 @@ async def create_valkey(request):
         cluster_mode = VALKEY_INFO["cluster_enabled"]
         if not cluster_mode:
             single = kwargs.pop("single_connection_client", False) or single_connection
-            url_options = parse_url(url, True)
+            url_options = parse_url(url)
             url_options.update(kwargs)
             pool = valkey.ConnectionPool(**url_options)
             client = cls(connection_pool=pool)
@@ -270,4 +269,4 @@ def valkey_url(request):
 @pytest.fixture()
 def connect_args(request):
     url = request.config.getoption("--valkey-url")
-    return parse_url(url, True)
+    return parse_url(url)

--- a/tests/test_asyncio/test_connection.py
+++ b/tests/test_asyncio/test_connection.py
@@ -11,13 +11,13 @@ from valkey._parsers import (
     _AsyncRESP2Parser,
     _AsyncRESP3Parser,
     _AsyncRESPBase,
-    parse_url,
 )
 from valkey.asyncio import ConnectionPool, Valkey
 from valkey.asyncio.connection import (
     Connection,
     SSLConnection,
     UnixDomainSocketConnection,
+    parse_url,
 )
 from valkey.asyncio.retry import Retry
 from valkey.backoff import NoBackoff
@@ -305,7 +305,7 @@ async def test_pool_auto_close(request, from_url):
     """Verify that basic Valkey instances have auto_close_connection_pool set to True"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, True)
+    url_args = parse_url(url)
 
     async def get_valkey_connection():
         if from_url:
@@ -347,7 +347,7 @@ async def test_pool_auto_close_disable(request):
     """Verify that auto_close_connection_pool can be disabled (deprecated)"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, True)
+    url_args = parse_url(url)
 
     async def get_valkey_connection():
         url_args["auto_close_connection_pool"] = False
@@ -366,7 +366,7 @@ async def test_valkey_connection_pool(request, from_url):
     have auto_close_connection_pool set to False"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, True)
+    url_args = parse_url(url)
 
     pool = None
 
@@ -398,7 +398,7 @@ async def test_valkey_from_pool(request, from_url):
     have auto_close_connection_pool set to True"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, True)
+    url_args = parse_url(url)
 
     pool = None
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,9 +6,14 @@ from unittest.mock import patch
 import pytest
 import valkey
 from valkey import ConnectionPool, Valkey
-from valkey._parsers import _LibvalkeyParser, _RESP2Parser, _RESP3Parser, parse_url
+from valkey._parsers import _LibvalkeyParser, _RESP2Parser, _RESP3Parser
 from valkey.backoff import NoBackoff
-from valkey.connection import Connection, SSLConnection, UnixDomainSocketConnection
+from valkey.connection import (
+    Connection,
+    SSLConnection,
+    UnixDomainSocketConnection,
+    parse_url,
+)
 from valkey.exceptions import ConnectionError, InvalidResponse, TimeoutError
 from valkey.retry import Retry
 from valkey.utils import LIBVALKEY_AVAILABLE
@@ -217,7 +222,7 @@ def test_pool_auto_close(request, from_url):
     """Verify that basic Valkey instances have auto_close_connection_pool set to True"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, False)
+    url_args = parse_url(url)
 
     def get_valkey_connection():
         if from_url:
@@ -235,7 +240,7 @@ def test_valkey_connection_pool(request, from_url):
     have auto_close_connection_pool set to False"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, True)
+    url_args = parse_url(url)
 
     pool = None
 
@@ -267,7 +272,7 @@ def test_valkey_from_pool(request, from_url):
     have auto_close_connection_pool set to True"""
 
     url: str = request.config.getoption("--valkey-url")
-    url_args = parse_url(url, True)
+    url_args = parse_url(url)
 
     pool = None
 
@@ -344,7 +349,7 @@ def test_unix_socket_connection_failure():
 
 
 def test_parsing_unix_socket_relative_path():
-    parsed = parse_url("unix:./valkey.sock", False)
+    parsed = parse_url("unix:./valkey.sock")
     assert parsed["path"] == "./valkey.sock"
     assert parsed["connection_class"] is UnixDomainSocketConnection
     assert len(parsed) == 2

--- a/valkey/asyncio/cluster.py
+++ b/valkey/asyncio/cluster.py
@@ -25,14 +25,19 @@ from valkey._cache import (
     DEFAULT_EVICTION_POLICY,
     AbstractCache,
 )
-from valkey._parsers import AsyncCommandsParser, Encoder, parse_url
+from valkey._parsers import AsyncCommandsParser, Encoder
 from valkey._parsers.helpers import (
     _ValkeyCallbacks,
     _ValkeyCallbacksRESP2,
     _ValkeyCallbacksRESP3,
 )
 from valkey.asyncio.client import ResponseCallbackT
-from valkey.asyncio.connection import Connection, DefaultParser, SSLConnection
+from valkey.asyncio.connection import (
+    Connection,
+    DefaultParser,
+    SSLConnection,
+    parse_url,
+)
 from valkey.asyncio.lock import Lock
 from valkey.asyncio.retry import Retry
 from valkey.backoff import default_backoff
@@ -214,7 +219,7 @@ class ValkeyCluster(AbstractValkey, AbstractValkeyCluster, AsyncValkeyClusterCom
         :class:`~valkey.asyncio.connection.Connection` when created.
         In the case of conflicting arguments, querystring arguments are used.
         """
-        kwargs.update(parse_url(url, True))
+        kwargs.update(parse_url(url))
         if kwargs.pop("connection_class", None) is SSLConnection:
             kwargs["ssl"] = True
         return cls(**kwargs)

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -71,6 +71,12 @@ SYM_LF = b"\n"
 SYM_EMPTY = b""
 
 
+def parse_url(url: str):
+    from .._parsers.url_parser import parse_url
+
+    return parse_url(url, async_connection=True)
+
+
 class _Sentinel(enum.Enum):
     sentinel = object()
 
@@ -1021,9 +1027,8 @@ class ConnectionPool:
         class initializer. In the case of conflicting arguments, querystring
         arguments always win.
         """
-        from .._parsers.url_parser import parse_url
 
-        url_options = parse_url(url, True)
+        url_options = parse_url(url)
         kwargs.update(url_options)
         return cls(**kwargs)
 

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -6,13 +6,13 @@ import time
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from valkey._parsers import CommandsParser, Encoder, parse_url
+from valkey._parsers import CommandsParser, Encoder
 from valkey._parsers.helpers import parse_scan
 from valkey.backoff import default_backoff
 from valkey.client import CaseInsensitiveDict, PubSub, Valkey
 from valkey.commands import READ_COMMANDS, ValkeyClusterCommands
 from valkey.commands.helpers import list_or_args
-from valkey.connection import ConnectionPool, DefaultParser
+from valkey.connection import ConnectionPool, DefaultParser, parse_url
 from valkey.crc import VALKEY_CLUSTER_HASH_SLOTS, key_slot
 from valkey.exceptions import (
     AskError,
@@ -580,7 +580,7 @@ class ValkeyCluster(AbstractValkeyCluster, ValkeyClusterCommands):
         from_url = False
         if url is not None:
             from_url = True
-            url_options = parse_url(url, False)
+            url_options = parse_url(url)
             if "path" in url_options:
                 raise ValkeyClusterException(
                     "ValkeyCluster does not currently support Unix Domain "

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -74,6 +74,12 @@ else:
     DefaultParser = _RESP2Parser
 
 
+def parse_url(url: str):
+    from ._parsers.url_parser import parse_url
+
+    return parse_url(url, async_connection=False)
+
+
 class LibvalkeyRespSerializer:
     def pack(self, *args) -> list[bytes]:
         """Pack a series of arguments into the Valkey protocol"""
@@ -1001,9 +1007,8 @@ class ConnectionPool:
         class initializer. In the case of conflicting arguments, querystring
         arguments always win.
         """
-        from ._parsers.url_parser import parse_url
 
-        url_options = parse_url(url, False)
+        url_options = parse_url(url)
         if "connection_class" in kwargs:
             url_options["connection_class"] = kwargs["connection_class"]
 


### PR DESCRIPTION
PR #29 moved a `parse_url` function into one unified implementation. However, it has also removed `parse_url` from `valkey.connection` and `valkey.asyncio.connection` which means that one can't call `valkey.connection.parse_url` anymore and instead has to call `valkey._parsers.parse_url` which is considered to be a private API call.

This commit fixes that by reintroducing the `parse_url` function in both `valkey.connection` and `valkey.asyncio.connection` by simply forwarding the call to `valkey._parsers.parse_url`.

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
