### PR TITLE
DO NOT MERGE: Add support for pypy-3.11, drop pypy-3.9

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,7 +89,7 @@ jobs:
        max-parallel: 15
        fail-fast: false
        matrix:
-         python-version: ['3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
+         python-version: ['3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.10', 'pypy-3.11']
          test-type: ['standalone', 'cluster']
          connection-type: ['libvalkey', 'plain']
          protocol-version: ['2','3']
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.9', 'pypy-3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.11.1', '3.12', '3.13', 'pypy-3.10', 'pypy-3.11']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -12,6 +12,6 @@ pytest-asyncio
 pytest-cov
 pytest-timeout
 ujson>=4.2.0
-uvloop
+uvloop; implementation_name != "pypy"
 vulture>=2.3.0
 wheel>=0.30.0


### PR DESCRIPTION

### Description of change

Please **DO NOT MERGE THIS PULL REQUEST**. I wanted to push it to see if anything breaks with PyPy 3.11.
This should be merged after we have 6.1.1, because we cannot drop support for any old Python version in a patch version. This requires 6.2.0.

<!-- Please provide a description of the change here. -->
