### PR TITLE
Fix broken external URLs in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ html_theme_options = {
     "footer_icons": [
         {
             "name": "GitHub",
-            "url": "https://github.com/valkey/valkey-py",
+            "url": "https://github.com/valkey-io/valkey-py",
             "html": """
             <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
                 <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
@@ -140,7 +140,7 @@ html_theme_options = {
             "class": "",
         },
     ],
-    "source_repository": "https://github.com/valkey/valkey-py/",
+    "source_repository": "https://github.com/valkey-io/valkey-py/",
     "source_branch": "master",
     "source_directory": "docs/",
 }

--- a/docs/examples/opentelemetry/README.md
+++ b/docs/examples/opentelemetry/README.md
@@ -10,7 +10,7 @@ for details.
 **Step 1**. Download the example using Git:
 
 ```shell
-git clone https://github.com/valkey/valkey-py.git
+git clone https://github.com/valkey-io/valkey-py.git
 cd example/opentelemetry
 ```
 

--- a/docs/resp3_features.rst
+++ b/docs/resp3_features.rst
@@ -1,7 +1,7 @@
 RESP 3 Features
 ===============
 
-valkey-py supports the `RESP 3 standard <https://github.com/valkey/valkey-specifications/blob/master/protocol/RESP3.md>`_. Practically, this means that client using RESP 3 will be faster and more performant as fewer type translations occur in the client. It also means new response types like doubles, true simple strings, maps, and booleans are available.
+valkey-py supports the `RESP 3 standard <https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md>`_. Practically, this means that client using RESP 3 will be faster and more performant as fewer type translations occur in the client. It also means new response types like doubles, true simple strings, maps, and booleans are available.
 
 Connecting
 -----------
@@ -51,7 +51,7 @@ Connecting to an OSS Valkey Cluster with RESP 3
 Push notifications
 ------------------
 
-Push notifications are a way that valkey sends out of band data. The RESP 3 protocol includes a `push type <https://github.com/valkey/valkey-specifications/blob/master/protocol/RESP3.md#push-type>`_ that allows our client to intercept these out of band messages. By default, clients will log simple messages, but valkey-py includes the ability to bring your own function processor.
+Push notifications are a way that valkey sends out of band data. The RESP 3 protocol includes a `push type <https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#push-type>`_ that allows our client to intercept these out of band messages. By default, clients will log simple messages, but valkey-py includes the ability to bring your own function processor.
 
 This means that should you want to perform something, on a given push notification, you specify a function during the connection, as per this examples:
 


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
  - See https://github.com/BjoernPetersen/valkey-py/actions/runs/17852442813 
- [x] (not applicable) Is the new or changed code fully tested?
- [x] (not applicable) Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] (not applicable) Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

I noticed that the link to this repository from https://valkey-py.readthedocs.io was broken, so here's a fix for that. While fixing that link, I also came across a few more that linked to the `valkey-specification` repo, which doesn't exist. RESP3 is controlled by Redis, so I changed the link back to their specification, as other Valkey repos seem to do as well.
