### PR TITLE
tests: fix lolwut tests

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -22,6 +22,7 @@ from valkey._parsers.helpers import (
 from valkey.client import EMPTY_RESPONSE, NEVER_DECODE
 
 from .conftest import (
+    VALKEY_INFO,
     _get_client,
     assert_geo_is_close,
     assert_resp_response,
@@ -844,11 +845,13 @@ class TestValkeyCommands:
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("5.0.0")
     def test_lolwut(self, r):
+        version = Version(VALKEY_INFO.get("version", "0"))
+        str_to_match = "Valkey ver." if version >= Version("9.0.0") else "Redis ver."
         lolwut = r.lolwut().decode("utf-8")
-        assert "Valkey ver." in lolwut
+        assert str_to_match in lolwut
 
         lolwut = r.lolwut(5, 6, 7, 8).decode("utf-8")
-        assert "Valkey ver." in lolwut
+        assert str_to_match in lolwut
 
     @pytest.mark.onlynoncluster
     @skip_if_server_version_lt("6.2.0")


### PR DESCRIPTION
Starting with Valkey 9.0, the `lolwut` command doesn't contain `Redis ver.` in the output, but `Valkey ver.`.

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
