### PR TITLE
Add MANIFEST.in to ensure py.typed is included in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include valkey/py.typed
+recursive-include valkey *.py
+recursive-include tests *.py


### PR DESCRIPTION
This PR adds a MANIFEST.in file to ensure the py.typed marker file (PEP 561) is included in source distributions.

Problem:
Some build systems that don't fully support PEP 517/518 pyproject.toml-based builds rely on MANIFEST.in to determine which files to include in the sdist. Without this file, the py.typed marker may be missing from source distributions built by these systems.
Solution:

Add a MANIFEST.in that explicitly includes:
valkey/py.typed - the PEP 561 type marker
All Python files in valkey/ and tests/

This follows the pattern used by redis-py and other typed Python packages for compatibility with legacy build systems.

Fixes https://github.com/valkey-io/valkey-py/issues/254