### PR TITLE
Add in min_connections to available arguments

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -468,6 +468,24 @@ class TestValkeyClusterObj:
 
         await rc.aclose()
 
+    async def test_min_connections(
+        self, create_valkey: Callable[..., ValkeyCluster]
+    ) -> None:
+        rc = await create_valkey(cls=ValkeyCluster, min_connections=5)
+        for node in rc.get_nodes():
+            assert node.min_connections == 5
+            assert len(node._connections) == 5
+            assert len(node._free) == 5
+        await rc.aclose()
+
+    async def test_min_connections_greater_than_max(
+        self, create_valkey: Callable[..., ValkeyCluster]
+    ) -> None:
+        with pytest.raises(ValkeyClusterException):
+            await create_valkey(
+                cls=ValkeyCluster, min_connections=20, max_connections=10
+            )
+
     async def test_execute_command_errors(self, r: ValkeyCluster) -> None:
         """
         Test that if no key is provided then exception should be raised.

--- a/tests/test_connection_pool.py
+++ b/tests/test_connection_pool.py
@@ -107,6 +107,37 @@ class TestConnectionPool:
         expected = "path=/abc,db=1,client_name=test-client"
         assert expected in repr(pool)
 
+    def test_min_connections(self):
+        pool = valkey.ConnectionPool(
+            connection_class=DummyConnection,
+            min_connections=5,
+        )
+        assert pool.min_connections == 5
+        assert len(pool._available_connections) == 5
+        assert pool._created_connections == 5
+
+    def test_min_connections_default(self):
+        pool = valkey.ConnectionPool(
+            connection_class=DummyConnection,
+        )
+        assert pool.min_connections == 0
+        assert len(pool._available_connections) == 0
+
+    def test_min_connections_greater_than_max_raises(self):
+        with pytest.raises(ValueError):
+            valkey.ConnectionPool(
+                connection_class=DummyConnection,
+                min_connections=20,
+                max_connections=10,
+            )
+
+    def test_min_connections_negative_raises(self):
+        with pytest.raises(ValueError):
+            valkey.ConnectionPool(
+                connection_class=DummyConnection,
+                min_connections=-1,
+            )
+
 
 class TestBlockingConnectionPool:
     def get_pool(self, connection_kwargs=None, max_connections=10, timeout=20):
@@ -195,6 +226,31 @@ class TestBlockingConnectionPool:
         )
         expected = "path=abc,db=0,client_name=test-client"
         assert expected in repr(pool)
+
+    def test_min_connections(self):
+        pool = valkey.BlockingConnectionPool(
+            connection_class=DummyConnection,
+            max_connections=10,
+            min_connections=5,
+        )
+        assert pool.min_connections == 5
+        assert len(pool._connections) == 5
+
+    def test_min_connections_default(self):
+        pool = valkey.BlockingConnectionPool(
+            connection_class=DummyConnection,
+            max_connections=10,
+        )
+        assert pool.min_connections == 0
+        assert len(pool._connections) == 0
+
+    def test_min_connections_greater_than_max_raises(self):
+        with pytest.raises(ValueError):
+            valkey.BlockingConnectionPool(
+                connection_class=DummyConnection,
+                min_connections=20,
+                max_connections=10,
+            )
 
 
 class TestConnectionPoolURLParsing:

--- a/valkey/asyncio/client.py
+++ b/valkey/asyncio/client.py
@@ -226,6 +226,7 @@ class Valkey(
         ssl_min_version: Optional[ssl.TLSVersion] = None,
         ssl_ciphers: Optional[str] = None,
         max_connections: Optional[int] = None,
+        min_connections: int = 0,
         single_connection_client: bool = False,
         health_check_interval: int = 0,
         client_name: Optional[str] = None,
@@ -251,6 +252,13 @@ class Valkey(
         `retry_on_error` to a list of the error/s to retry on, then set
         `retry` to a valid `Retry` object.
         To retry on TimeoutError, `retry_on_timeout` can also be set to `True`.
+
+        Args:
+            max_connections: The maximum number of connections for the pool.
+            min_connections: The minimum number of connections to pre-create
+                when the pool is initialized. These connections are eagerly
+                connected when the client is first awaited or used.
+                Defaults to 0.
         """
         kwargs: Dict[str, Any]
         # auto_close_connection_pool only has an effect if connection_pool is
@@ -287,6 +295,7 @@ class Valkey(
                 "retry_on_error": retry_on_error,
                 "retry": copy.deepcopy(retry),
                 "max_connections": max_connections,
+                "min_connections": min_connections,
                 "health_check_interval": health_check_interval,
                 "client_name": client_name,
                 "lib_name": lib_name,
@@ -368,6 +377,7 @@ class Valkey(
         return self.initialize().__await__()
 
     async def initialize(self: _ValkeyT) -> _ValkeyT:
+        await self.connection_pool.initialize()
         if self.single_connection_client:
             async with self._single_conn_lock:
                 if self.connection is None:

--- a/valkey/client.py
+++ b/valkey/client.py
@@ -204,6 +204,7 @@ class Valkey(ValkeyModuleCommands, CoreCommands, SentinelCommands):
         ssl_min_version=None,
         ssl_ciphers=None,
         max_connections=None,
+        min_connections=0,
         single_connection_client=False,
         health_check_interval=0,
         client_name=None,
@@ -231,6 +232,11 @@ class Valkey(ValkeyModuleCommands, CoreCommands, SentinelCommands):
 
         Args:
 
+        max_connections:
+            The maximum number of connections for the pool.
+        min_connections:
+            The minimum number of connections to pre-create and connect
+            when the pool is initialized. Defaults to 0.
         single_connection_client:
             if `True`, connection pool is not used. In that case `Valkey`
             instance use is not thread safe.
@@ -265,6 +271,7 @@ class Valkey(ValkeyModuleCommands, CoreCommands, SentinelCommands):
                 "retry_on_error": retry_on_error,
                 "retry": copy.deepcopy(retry),
                 "max_connections": max_connections,
+                "min_connections": min_connections,
                 "health_check_interval": health_check_interval,
                 "client_name": client_name,
                 "lib_name": lib_name,

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -146,6 +146,7 @@ VALKEY_ALLOWED_KEYS = (
     "lib_name",
     "lib_version",
     "max_connections",
+    "min_connections",
     "nodes_flag",
     "valkey_connect_func",
     "password",
@@ -562,7 +563,8 @@ class ValkeyCluster(AbstractValkeyCluster, ValkeyClusterCommands):
 
          :**kwargs:
              Extra arguments that will be sent into Valkey instance when created
-             (See Official valkey-py doc for supported kwargs)
+             (See Official valkey-py doc for supported kwargs
+             e.g. ``max_connections``, ``min_connections``)
              Some kwargs are not supported and will raise a
              ValkeyClusterException:
                  - db (Valkey do not support database SELECT in cluster mode)


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

### Description of change

This change allows for setting a minimum number of connections that the client should initialize and keep-alive, similar to functionality other language libraries provide:https://github.com/valkey-io/valkey-java. This mostly helps for systems that are exposed to sudden changes in load, such as when behind a load balancer without a gradual warm up.

I have tested this in our dev environment by running load tests with and without this change. Without the change, p99 latency of valkey commands (for this load test, a FT.SEARCH) jumps to over 200 ms (as measured by the application) until load subsides. With the change, p99 latency is higher than a gradual warmup but remains under 20ms (as measured by the application). These load tests were measured on the same hardware running the application, and a single shard with 2 replicas (all replica CPU utilization was below 10% for entire load test)

First time contributing, so let me know if I did anything wrong! Also have a stronger background on the JVM, so if I'm missing python idioms let me know.