### PR TITLE
Drop "-dev" from py314

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -89,7 +89,15 @@ jobs:
        max-parallel: 15
        fail-fast: false
        matrix:
-         python-version: ['3.10', '3.11', '3.11.1', '3.12', '3.13', '3.14-dev', 'pypy-3.10', 'pypy-3.11']
+         python-version:
+          - '3.10'
+          - '3.11'
+          - '3.11.1'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+          - 'pypy-3.10'
+          - 'pypy-3.11'
          test-type: ['standalone', 'cluster']
          connection-type: ['libvalkey', 'plain']
          protocol-version: ['2','3']
@@ -127,9 +135,7 @@ jobs:
             ./util/wait-for-it.sh localhost:16379
            fi
            make ${{matrix.test-type}}-tests PROTOCOL=${{ matrix.protocol-version }}
-           # TODO: remove check for 3.14 once it's fixed
-           # https://github.com/MagicStack/uvloop/issues/637
-           if [[ "${{matrix.python-version}}" != pypy-* && "${{matrix.python-version}}" != "3.14-dev" ]]; then
+           if [[ "${{matrix.python-version}}" != pypy-* ]]; then
             make ${{matrix.test-type}}-tests USE_UVLOOP=1 PROTOCOL=${{ matrix.protocol-version }}
            fi
 
@@ -180,7 +186,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.11.1', '3.12', '3.13', '3.14-dev', 'pypy-3.10', 'pypy-3.11']
+        python-version:
+          - '3.10'
+          - '3.11'
+          - '3.11.1'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+          - 'pypy-3.10'
+          - 'pypy-3.11'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

This PR introduces the following changes:

* The "dev" suffix for Python 3.14 is dropped, as it's GA now