### PR TITLE
fix(asyncio-cluster): await stale node teardown before replacing cluster nodes

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2697,6 +2697,8 @@ class TestNodesManager:
         else:
             assert startup_nodes == ["my@DNS.com:7000"]
 
+        await rc.aclose()
+
 
 class TestClusterPipeline:
     """Tests for the ClusterPipeline class."""

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -112,6 +112,16 @@ class NodeProxy:
             await writer.drain()
 
 
+class BlockingDisconnectConnection:
+    def __init__(self, event: asyncio.Event) -> None:
+        self._event = event
+        self.is_connected = True
+
+    async def disconnect(self) -> None:
+        await self._event.wait()
+        self.is_connected = False
+
+
 @pytest_asyncio.fixture()
 async def slowlog(r: ValkeyCluster) -> None:
     """
@@ -2457,6 +2467,55 @@ class TestNodesManager:
         assert len(n_manager.nodes_cache) == 6
 
         await rc.aclose()
+
+    async def test_initialize_waits_for_removed_node_disconnect(self) -> None:
+        disconnect_event = asyncio.Event()
+        old_node = ClusterNode("127.0.0.1", 7009, PRIMARY)
+        old_node._connections.append(BlockingDisconnectConnection(disconnect_event))
+        startup_node = ClusterNode(default_host, default_port)
+        manager = NodesManager([startup_node], False, {})
+        manager.nodes_cache = {old_node.name: old_node}
+
+        captured_contexts = []
+        loop = asyncio.get_running_loop()
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(
+            lambda _loop, context: captured_contexts.append(context)
+        )
+
+        async def mocked_execute_command(self, *args, **kwargs):
+            assert args[0] == "CLUSTER SLOTS"
+            return [[0, 16383, [default_host, default_port, "node_0"]]]
+
+        try:
+            with mock.patch.object(
+                ClusterNode,
+                "execute_command",
+                autospec=True,
+                side_effect=mocked_execute_command,
+            ):
+                initialize_task = asyncio.create_task(manager.initialize())
+                await asyncio.sleep(0)
+
+                assert not initialize_task.done()
+
+                disconnect_event.set()
+                await initialize_task
+
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always", ResourceWarning)
+                    old_node.__del__()
+
+                resource_warnings = [
+                    warning
+                    for warning in caught
+                    if issubclass(warning.category, ResourceWarning)
+                ]
+                assert resource_warnings == []
+                assert captured_contexts == []
+        finally:
+            disconnect_event.set()
+            loop.set_exception_handler(previous_handler)
 
     async def test_init_slots_cache_cluster_mode_disabled(self) -> None:
         """

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -113,12 +113,31 @@ class NodeProxy:
 
 
 class BlockingDisconnectConnection:
-    def __init__(self, event: asyncio.Event) -> None:
+    def __init__(
+        self,
+        event: asyncio.Event,
+        started_event: Optional[asyncio.Event] = None,
+    ) -> None:
         self._event = event
+        self._started_event = started_event
         self.is_connected = True
 
     async def disconnect(self) -> None:
+        if self._started_event is not None:
+            self._started_event.set()
         await self._event.wait()
+        self.is_connected = False
+
+
+class FlakyDisconnectConnection:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.calls = 0
+
+    async def disconnect(self) -> None:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("disconnect failed")
         self.is_connected = False
 
 
@@ -2470,10 +2489,13 @@ class TestNodesManager:
 
     async def test_initialize_waits_for_removed_node_disconnect(self) -> None:
         disconnect_event = asyncio.Event()
+        disconnect_started_event = asyncio.Event()
         old_node = ClusterNode("127.0.0.1", 7009, PRIMARY)
-        old_node._connections.append(BlockingDisconnectConnection(disconnect_event))
+        old_node._connections.append(
+            BlockingDisconnectConnection(disconnect_event, disconnect_started_event)
+        )
         startup_node = ClusterNode(default_host, default_port)
-        manager = NodesManager([startup_node], False, {})
+        manager = NodesManager([startup_node], False, {}, dynamic_startup_nodes=False)
         manager.nodes_cache = {old_node.name: old_node}
 
         captured_contexts = []
@@ -2495,7 +2517,7 @@ class TestNodesManager:
                 side_effect=mocked_execute_command,
             ):
                 initialize_task = asyncio.create_task(manager.initialize())
-                await asyncio.sleep(0)
+                await disconnect_started_event.wait()
 
                 assert not initialize_task.done()
 
@@ -2516,6 +2538,48 @@ class TestNodesManager:
         finally:
             disconnect_event.set()
             loop.set_exception_handler(previous_handler)
+
+    async def test_initialize_warns_and_retries_stale_disconnect_errors(self) -> None:
+        flaky_connection = FlakyDisconnectConnection()
+        old_node = ClusterNode("127.0.0.1", 7009, PRIMARY)
+        old_node._connections.append(flaky_connection)
+        startup_node = ClusterNode(default_host, default_port)
+        manager = NodesManager([startup_node], False, {}, dynamic_startup_nodes=False)
+        manager.nodes_cache = {old_node.name: old_node}
+
+        async def mocked_execute_command(self, *args, **kwargs):
+            assert args[0] == "CLUSTER SLOTS"
+            return [[0, 16383, [default_host, default_port, "node_0"]]]
+
+        with mock.patch.object(
+            ClusterNode,
+            "execute_command",
+            autospec=True,
+            side_effect=mocked_execute_command,
+        ):
+            with pytest.warns(
+                RuntimeWarning, match="disconnecting stale cluster nodes"
+            ):
+                await manager.initialize()
+
+            assert manager._pending_node_disconnects == {old_node.name: old_node}
+            assert flaky_connection.calls == 1
+
+            await manager.aclose()
+
+            assert manager._pending_node_disconnects == {}
+            assert flaky_connection.calls == 2
+
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always", ResourceWarning)
+                old_node.__del__()
+
+            resource_warnings = [
+                warning
+                for warning in caught
+                if issubclass(warning.category, ResourceWarning)
+            ]
+            assert resource_warnings == []
 
     async def test_init_slots_cache_cluster_mode_disabled(self) -> None:
         """

--- a/valkey/asyncio/cluster.py
+++ b/valkey/asyncio/cluster.py
@@ -1233,14 +1233,27 @@ class NodesManager:
         if not self._pending_node_disconnects:
             return
 
-        nodes = tuple(self._pending_node_disconnects.values())
-        self._pending_node_disconnects.clear()
+        pending_items = tuple(self._pending_node_disconnects.items())
         ret = await asyncio.gather(
-            *(node.disconnect() for node in nodes), return_exceptions=True
+            *(node.disconnect() for _, node in pending_items), return_exceptions=True
         )
-        exc = next((res for res in ret if isinstance(res, Exception)), None)
-        if exc:
-            raise exc
+        errors = []
+        for (name, node), res in zip(pending_items, ret):
+            if self._pending_node_disconnects.get(name) is not node:
+                continue
+            if isinstance(res, Exception):
+                errors.append(res)
+                continue
+            self._pending_node_disconnects.pop(name, None)
+
+        if errors:
+            msg = ", ".join(f"{type(err).__name__}: {err}" for err in errors)
+            warnings.warn(
+                "Error(s) while disconnecting stale cluster nodes during "
+                f"topology refresh: {msg}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     def _update_moved_slots(self) -> None:
         e = self._moved_exception

--- a/valkey/asyncio/cluster.py
+++ b/valkey/asyncio/cluster.py
@@ -781,9 +781,7 @@ class ValkeyCluster(AbstractValkey, AbstractValkeyCluster, AsyncValkeyClusterCom
                     keys = [node.name for node in target_nodes]
                     values = await asyncio.gather(
                         *(
-                            asyncio.create_task(
-                                self._execute_command(node, *args, **kwargs)
-                            )
+                            self._execute_command(node, *args, **kwargs)
                             for node in target_nodes
                         )
                     )
@@ -1057,10 +1055,7 @@ class ClusterNode:
 
     async def disconnect(self) -> None:
         ret = await asyncio.gather(
-            *(
-                asyncio.create_task(connection.disconnect())
-                for connection in self._connections
-            ),
+            *(connection.disconnect() for connection in self._connections),
             return_exceptions=True,
         )
         exc = next((res for res in ret if isinstance(res, Exception)), None)
@@ -1165,6 +1160,7 @@ class ClusterNode:
 class NodesManager:
     __slots__ = (
         "_moved_exception",
+        "_pending_node_disconnects",
         "connection_kwargs",
         "default_node",
         "nodes_cache",
@@ -1195,6 +1191,7 @@ class NodesManager:
         self.slots_cache: Dict[int, List["ClusterNode"]] = {}
         self.read_load_balancer = LoadBalancer()
         self._moved_exception: MovedError = None
+        self._pending_node_disconnects: Dict[str, "ClusterNode"] = {}
 
     def get_node(
         self,
@@ -1223,14 +1220,27 @@ class NodesManager:
         if remove_old:
             for name in list(old.keys()):
                 if name not in new:
-                    task = asyncio.create_task(old.pop(name).disconnect())  # noqa
+                    self._pending_node_disconnects[name] = old.pop(name)
 
         for name, node in new.items():
             if name in old:
                 if old[name] is node:
                     continue
-                task = asyncio.create_task(old[name].disconnect())  # noqa
+                self._pending_node_disconnects[name] = old[name]
             old[name] = node
+
+    async def _close_pending_node_disconnects(self) -> None:
+        if not self._pending_node_disconnects:
+            return
+
+        nodes = tuple(self._pending_node_disconnects.values())
+        self._pending_node_disconnects.clear()
+        ret = await asyncio.gather(
+            *(node.disconnect() for node in nodes), return_exceptions=True
+        )
+        exc = next((res for res in ret if isinstance(res, Exception)), None)
+        if exc:
+            raise exc
 
     def _update_moved_slots(self) -> None:
         e = self._moved_exception
@@ -1418,10 +1428,12 @@ class NodesManager:
         # Set the tmp variables to the real variables
         self.slots_cache = tmp_slots
         self.set_nodes(self.nodes_cache, tmp_nodes_cache, remove_old=True)
+        await self._close_pending_node_disconnects()
 
         if self._dynamic_startup_nodes:
             # Populate the startup nodes with all discovered nodes
             self.set_nodes(self.startup_nodes, self.nodes_cache, remove_old=True)
+            await self._close_pending_node_disconnects()
 
         # Set the default node
         self.default_node = self.get_nodes_by_server_type(PRIMARY)[0]
@@ -1430,11 +1442,9 @@ class NodesManager:
 
     async def aclose(self, attr: str = "nodes_cache") -> None:
         self.default_node = None
+        await self._close_pending_node_disconnects()
         await asyncio.gather(
-            *(
-                asyncio.create_task(node.disconnect())
-                for node in getattr(self, attr).values()
-            )
+            *(node.disconnect() for node in getattr(self, attr).values())
         )
 
     def remap_host_port(self, host: str, port: int) -> Tuple[str, int]:
@@ -1635,10 +1645,7 @@ class ClusterPipeline(
             nodes[node.name][1].append(cmd)
 
         errors = await asyncio.gather(
-            *(
-                asyncio.create_task(node[0].execute_pipeline(node[1]))
-                for node in nodes.values()
-            )
+            *(node[0].execute_pipeline(node[1]) for node in nodes.values())
         )
 
         if any(errors):


### PR DESCRIPTION
Avoid fire-and-forget disconnects when refreshing the async cluster topology.
This keeps removed ClusterNode instances alive until teardown finishes and fixes the unclosed node warning regression during reinitialization.

Fixes #185 

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
