### PR TITLE
Fix cluster pipeline retries for connection timeouts

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -2807,17 +2807,18 @@ class TestClusterPipeline:
         key = "foo"
         await r.set(key, "value")
         execute_pipeline = ClusterNode.execute_pipeline
-        attempts = {"count": 0}
+        attempts = 0
 
         async def raise_timeout_once(self, commands):
-            attempts["count"] += 1
-            if attempts["count"] == 1:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
                 raise TimeoutError("error")
             return await execute_pipeline(self, commands)
 
         with mock.patch.object(ClusterNode, "execute_pipeline", new=raise_timeout_once):
             assert await r.pipeline().get(key).execute() == [b"value"]
-            assert attempts["count"] == 2
+            assert attempts == 2
 
     async def test_asking_error(self, r: ValkeyCluster) -> None:
         """Test AskError handling."""

--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -33,6 +33,7 @@ from valkey.exceptions import (
     MovedError,
     NoPermissionError,
     ResponseError,
+    TimeoutError,
     ValkeyClusterException,
     ValkeyError,
 )
@@ -2801,6 +2802,22 @@ class TestClusterPipeline:
             async with r.pipeline() as pipe:
                 with pytest.raises(ConnectionError):
                     await pipe.get(key).get(key).execute(raise_on_error=True)
+
+    async def test_timeout_error_retried(self, r: ValkeyCluster) -> None:
+        key = "foo"
+        await r.set(key, "value")
+        execute_pipeline = ClusterNode.execute_pipeline
+        attempts = {"count": 0}
+
+        async def raise_timeout_once(self, commands):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise TimeoutError("error")
+            return await execute_pipeline(self, commands)
+
+        with mock.patch.object(ClusterNode, "execute_pipeline", new=raise_timeout_once):
+            assert await r.pipeline().get(key).execute() == [b"value"]
+            assert attempts["count"] == 2
 
     async def test_asking_error(self, r: ValkeyCluster) -> None:
         """Test AskError handling."""

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3213,6 +3213,37 @@ class TestClusterPipeline:
             with pytest.raises(ConnectionError):
                 pipe.get(key).get(key).execute(raise_on_error=True)
 
+    def test_timeout_error_get_connection_retried(self, r):
+        key = "foo"
+        r.set(key, "value")
+        orig_get_connection = valkey.cluster.get_connection
+        attempts = {"count": 0}
+
+        def raise_timeout_once(*args, **kwargs):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise TimeoutError("error")
+            return orig_get_connection(*args, **kwargs)
+
+        with patch("valkey.cluster.get_connection", side_effect=raise_timeout_once):
+            with patch.object(
+                r.nodes_manager, "initialize", wraps=r.nodes_manager.initialize
+            ) as initialize:
+                assert r.pipeline().get(key).execute() == [b"value"]
+                assert attempts["count"] == 2
+                assert initialize.call_count == 1
+
+    def test_timeout_error_get_connection_raised(self, r):
+        key = "foo"
+
+        with patch("valkey.cluster.get_connection", side_effect=TimeoutError("error")):
+            with patch.object(
+                r.nodes_manager, "initialize", wraps=r.nodes_manager.initialize
+            ) as initialize:
+                with pytest.raises(TimeoutError):
+                    r.pipeline().get(key).execute()
+                assert initialize.call_count == r.cluster_error_retry_attempts + 1
+
     def test_asking_error(self, r):
         """
         Test redirection on ASK error

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -29,6 +29,7 @@ from valkey.connection import BlockingConnectionPool, Connection, ConnectionPool
 from valkey.crc import key_slot
 from valkey.exceptions import (
     AskError,
+    AuthenticationError,
     ClusterDownError,
     ConnectionError,
     DataError,
@@ -36,6 +37,7 @@ from valkey.exceptions import (
     NoPermissionError,
     ResponseError,
     TimeoutError,
+    TryAgainError,
     ValkeyClusterException,
     ValkeyError,
 )
@@ -3246,6 +3248,40 @@ class TestClusterPipeline:
         ):
             r.pipeline().get(key).execute()
         assert initialize.call_count == r.cluster_error_retry_attempts + 1
+
+    def test_annotate_exception_handles_empty_args(self, r):
+        pipe = r.pipeline()
+        exception = TryAgainError()
+
+        pipe.annotate_exception(exception, 1, ("GET", "foo"))
+
+        assert exception.args == (
+            "Command # 1 (GET foo) of pipeline caused error: TryAgainError",
+        )
+
+    def test_non_retryable_get_connection_error_releases_connections(self, r):
+        # in order to ensure that a pipeline will make use of connections
+        # from different nodes
+        assert r.keyslot("a") != r.keyslot("b")
+
+        orig_get_connection = valkey.cluster.get_connection
+
+        with patch("valkey.cluster.get_connection") as get_connection:
+
+            def raise_non_retryable(target_node, *args, **kwargs):
+                if get_connection.call_count == 2:
+                    raise AuthenticationError("mocked auth error")
+                return orig_get_connection(target_node, *args, **kwargs)
+
+            get_connection.side_effect = raise_non_retryable
+
+            with pytest.raises(AuthenticationError):
+                r.pipeline().get("a").get("b").execute()
+
+        for cluster_node in r.nodes_manager.nodes_cache.values():
+            connection_pool = cluster_node.valkey_connection.connection_pool
+            num_of_conns = len(connection_pool._available_connections)
+            assert num_of_conns == connection_pool._created_connections
 
     def test_asking_error(self, r):
         """

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3217,11 +3217,12 @@ class TestClusterPipeline:
         key = "foo"
         r.set(key, "value")
         orig_get_connection = valkey.cluster.get_connection
-        attempts = {"count": 0}
+        attempts = 0
 
         def raise_timeout_once(*args, **kwargs):
-            attempts["count"] += 1
-            if attempts["count"] == 1:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
                 raise TimeoutError("error")
             return orig_get_connection(*args, **kwargs)
 
@@ -3230,19 +3231,21 @@ class TestClusterPipeline:
                 r.nodes_manager, "initialize", wraps=r.nodes_manager.initialize
             ) as initialize:
                 assert r.pipeline().get(key).execute() == [b"value"]
-                assert attempts["count"] == 2
+                assert attempts == 2
                 assert initialize.call_count == 1
 
     def test_timeout_error_get_connection_raised(self, r):
         key = "foo"
 
-        with patch("valkey.cluster.get_connection", side_effect=TimeoutError("error")):
-            with patch.object(
+        with (
+            patch("valkey.cluster.get_connection", side_effect=TimeoutError("error")),
+            patch.object(
                 r.nodes_manager, "initialize", wraps=r.nodes_manager.initialize
-            ) as initialize:
-                with pytest.raises(TimeoutError):
-                    r.pipeline().get(key).execute()
-                assert initialize.call_count == r.cluster_error_retry_attempts + 1
+            ) as initialize,
+            pytest.raises(TimeoutError),
+        ):
+            r.pipeline().get(key).execute()
+        assert initialize.call_count == r.cluster_error_retry_attempts + 1
 
     def test_asking_error(self, r):
         """

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -2035,9 +2035,10 @@ class ClusterPipeline(ValkeyCluster):
         Provides extra context to the exception prior to it being handled
         """
         cmd = " ".join(map(safe_str, command))
-        msg = (
-            f"Command # {number} ({cmd}) of pipeline caused error: {exception.args[0]}"
-        )
+        error_message = exception.args[0] if exception.args else str(exception)
+        if not error_message:
+            error_message = exception.__class__.__name__
+        msg = f"Command # {number} ({cmd}) of pipeline caused error: {error_message}"
         exception.args = (msg,) + exception.args[1:]
 
     def execute(self, raise_on_error=True):
@@ -2176,10 +2177,10 @@ class ClusterPipeline(ValkeyCluster):
                     try:
                         connection = get_connection(valkey_node, c.args)
                     except Exception as e:
-                        if type(e) not in self.__class__.REINITIALIZE_ERRORS:
-                            raise
                         for n in nodes.values():
                             n.connection_pool.release(n.connection)
+                        if type(e) not in self.__class__.REINITIALIZE_ERRORS:
+                            raise
                         # Connection retries are being handled in the node's
                         # Retry object. Reinitialize the node -> slot table.
                         self.nodes_manager.initialize()

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -1617,7 +1617,7 @@ class NodesManager:
                             if len(disagreements) > 5:
                                 raise ValkeyClusterException(
                                     f"startup_nodes could not agree on a valid "
-                                    f'slots cache: {", ".join(disagreements)}'
+                                    f"slots cache: {', '.join(disagreements)}"
                                 )
 
             fully_covered = self.check_slots_coverage(tmp_slots)
@@ -2036,8 +2036,7 @@ class ClusterPipeline(ValkeyCluster):
         """
         cmd = " ".join(map(safe_str, command))
         msg = (
-            f"Command # {number} ({cmd}) of pipeline "
-            f"caused error: {exception.args[0]}"
+            f"Command # {number} ({cmd}) of pipeline caused error: {exception.args[0]}"
         )
         exception.args = (msg,) + exception.args[1:]
 
@@ -2118,7 +2117,7 @@ class ClusterPipeline(ValkeyCluster):
                     retry_attempts -= 1
                     pass
                 else:
-                    raise e
+                    raise
 
     def _send_cluster_commands(
         self, stack, raise_on_error=True, allow_redirections=True
@@ -2186,7 +2185,7 @@ class ClusterPipeline(ValkeyCluster):
                         self.nodes_manager.initialize()
                         if is_default_node:
                             self.replace_default_node()
-                        raise e
+                        raise
                     nodes[node_name] = NodeCommands(
                         valkey_node.parse_response,
                         valkey_node.connection_pool,

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -422,7 +422,8 @@ class AbstractValkeyCluster:
         list_keys_to_dict(["SCRIPT FLUSH"], lambda command, res: all(res.values())),
     )
 
-    ERRORS_ALLOW_RETRY = (ConnectionError, TimeoutError, ClusterDownError)
+    REINITIALIZE_ERRORS = (ConnectionError, TimeoutError, ClusterDownError)
+    ERRORS_ALLOW_RETRY = REINITIALIZE_ERRORS
 
     def replace_default_node(self, target_node: "ClusterNode" = None) -> None:
         """Replace the default cluster node.
@@ -1933,9 +1934,8 @@ class ClusterPipeline(ValkeyCluster):
     in cluster mode
     """
 
-    ERRORS_ALLOW_RETRY = (
-        ConnectionError,
-        TimeoutError,
+    REINITIALIZE_ERRORS = AbstractValkeyCluster.REINITIALIZE_ERRORS
+    ERRORS_ALLOW_RETRY = REINITIALIZE_ERRORS + (
         MovedError,
         AskError,
         TryAgainError,
@@ -2111,8 +2111,8 @@ class ClusterPipeline(ValkeyCluster):
                     raise_on_error=raise_on_error,
                     allow_redirections=allow_redirections,
                 )
-            except (ClusterDownError, ConnectionError) as e:
-                if retry_attempts > 0:
+            except Exception as e:
+                if retry_attempts > 0 and type(e) in self.__class__.REINITIALIZE_ERRORS:
                     # Try again with the new cluster setup. All other errors
                     # should be raised.
                     retry_attempts -= 1
@@ -2176,7 +2176,9 @@ class ClusterPipeline(ValkeyCluster):
                     valkey_node = self.get_valkey_connection(node)
                     try:
                         connection = get_connection(valkey_node, c.args)
-                    except ConnectionError:
+                    except Exception as e:
+                        if type(e) not in self.__class__.REINITIALIZE_ERRORS:
+                            raise
                         for n in nodes.values():
                             n.connection_pool.release(n.connection)
                         # Connection retries are being handled in the node's
@@ -2184,7 +2186,7 @@ class ClusterPipeline(ValkeyCluster):
                         self.nodes_manager.initialize()
                         if is_default_node:
                             self.replace_default_node()
-                        raise
+                        raise e
                     nodes[node_name] = NodeCommands(
                         valkey_node.parse_response,
                         valkey_node.connection_pool,


### PR DESCRIPTION
Reuse the shared cluster reinitialize error set so pipeline connection checkout timeouts refresh topology and retry like single commands. Add sync regression coverage for get_connection() timeouts and an asyncio guard test for existing retry behavior.

Fixes #261

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
