### PR TITLE
Docs: Fix "reference target not found" for Python stdlib classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,10 +31,18 @@ extensions = [
     "nbsphinx",
     "sphinx_gallery.load_style",
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.napoleon",
 ]
+
+# Allow cross-linking of types from the Valkey docs to the Python docs.
+# For example, functions with type annotations for `datetime.datetime`
+# will link to the Python docs.
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
 
 # Napoleon settings. We only accept Google-style docstrings.
 napoleon_google_docstring = True


### PR DESCRIPTION
Enabling the builtin `intersphinx` extension resolves build warnings like:

```
WARNING: py:class reference target not found: datetime.datetime [ref.class]
```

This resolves 39 warnings, and results in linked method parameter types:

### Before

> <img width="796" height="269" alt="image" src="https://github.com/user-attachments/assets/9e175287-33a2-453a-9dc5-f60c18d62318" />

### After

> <img width="799" height="269" alt="image" src="https://github.com/user-attachments/assets/a487f06e-db6f-428d-9818-ac11086525af" />


### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
