### PR TITLE
Fix ClusterPubSub limitation links

### DIFF
--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -434,8 +434,8 @@ class TestPubSubMessages:
         await p.aclose()
 
     @pytest.mark.onlynoncluster
-    # see: https://valkey-py-cluster.readthedocs.io/en/stable/pubsub.html
-    # #known-limitations-with-pubsub
+    # see: https://valkey-py.readthedocs.io/en/latest/clustering.html
+    # #known-pubsub-limitations
     async def test_unicode_pattern_message_handler(self, r: valkey.Valkey):
         p = r.pubsub(ignore_subscribe_messages=True)
         pattern = "uni" + chr(4456) + "*"

--- a/tests/test_asyncio/test_pubsub.py
+++ b/tests/test_asyncio/test_pubsub.py
@@ -434,8 +434,7 @@ class TestPubSubMessages:
         await p.aclose()
 
     @pytest.mark.onlynoncluster
-    # see: https://valkey-py.readthedocs.io/en/latest/clustering.html
-    # #known-pubsub-limitations
+    # see: https://valkey-py.readthedocs.io/en/latest/clustering.html#known-pubsub-limitations # noqa: E501
     async def test_unicode_pattern_message_handler(self, r: valkey.Valkey):
         p = r.pubsub(ignore_subscribe_messages=True)
         pattern = "uni" + chr(4456) + "*"

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -569,8 +569,8 @@ class TestPubSubMessages:
         assert self.message == make_message("smessage", channel, "test message")
 
     @pytest.mark.onlynoncluster
-    # see: https://valkey-py-cluster.readthedocs.io/en/stable/pubsub.html
-    # #known-limitations-with-pubsub
+    # see: https://valkey-py.readthedocs.io/en/latest/clustering.html
+    # #known-pubsub-limitations
     def test_unicode_pattern_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         pattern = "uni" + chr(4456) + "*"

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -569,8 +569,7 @@ class TestPubSubMessages:
         assert self.message == make_message("smessage", channel, "test message")
 
     @pytest.mark.onlynoncluster
-    # see: https://valkey-py.readthedocs.io/en/latest/clustering.html
-    # #known-pubsub-limitations
+    # see: https://valkey-py.readthedocs.io/en/latest/clustering.html#known-pubsub-limitations # noqa: E501
     def test_unicode_pattern_message_handler(self, r):
         p = r.pubsub(ignore_subscribe_messages=True)
         pattern = "uni" + chr(4456) + "*"

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -1700,7 +1700,7 @@ class ClusterPubSub(PubSub):
 
     IMPORTANT: before using ClusterPubSub, read about the known limitations
     with pubsub in Cluster mode and learn how to workaround them:
-    https://valkey-py-cluster.readthedocs.io/en/stable/pubsub.html
+    https://valkey-py.readthedocs.io/en/latest/clustering.html#known-pubsub-limitations
     """
 
     def __init__(


### PR DESCRIPTION
### Description of change

<!-- Please provide a description of the change here. -->
The Read the Docs project `valkey-py-cluster` doesn't exist. This was likely caused by a `redis->valkey` search and replace.

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

