### PR TITLE
Fix resource warnings: unclosed sockets / SSL sockets / a PEM file

### DIFF
--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -263,6 +263,8 @@ class TestSSL:
         ctx.use_certificate_file(self.CLIENT_CERT)
         ctx.use_privatekey_file(self.CLIENT_KEY)
 
+        with open(self.SERVER_CERT, "rb") as file:
+            server_cert = file.read()
         r = valkey.Valkey(
             host=p[0],
             port=p[1],
@@ -272,7 +274,7 @@ class TestSSL:
             ssl_cert_reqs="required",
             ssl_ca_certs=self.CA_CERT,
             ssl_ocsp_context=ctx,
-            ssl_ocsp_expected_cert=open(self.SERVER_CERT, "rb").read(),
+            ssl_ocsp_expected_cert=server_cert,
             ssl_validate_ocsp_stapled=True,
         )
 

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -908,11 +908,20 @@ class SSLConnection(Connection):
             )
 
             #  need another socket
-            con = OpenSSL.SSL.Connection(staple_ctx, socket.socket())
-            con.request_ocsp()
-            con.connect((self.host, self.port))
-            con.do_handshake()
-            con.shutdown()
+            ocsp_socket = socket.socket()
+            try:
+                con = OpenSSL.SSL.Connection(staple_ctx, ocsp_socket)
+                con.request_ocsp()
+                con.connect((self.host, self.port))
+                con.do_handshake()
+                con.shutdown()
+            except Exception:
+                # sslsock must be closed to prevent a ResourceWarning.
+                sslsock.close()
+                raise
+            finally:
+                # Always close the OCSP socket to prevent a ResourceWarning.
+                ocsp_socket.close()
             return sslsock
 
         # pure ocsp validation
@@ -920,10 +929,15 @@ class SSLConnection(Connection):
             from .ocsp import OCSPVerifier
 
             o = OCSPVerifier(sslsock, self.host, self.port, self.ca_certs)
-            if o.is_valid():
-                return sslsock
-            else:
-                raise ConnectionError("ocsp validation error")
+            try:
+                # `o.is_valid()` may raise an exception, in addition to returning False.
+                if not o.is_valid():
+                    raise ConnectionError("ocsp validation error")
+            except Exception:
+                # sslsock must be closed to prevent a ResourceWarning.
+                sslsock.close()
+                raise
+
         return sslsock
 
 


### PR DESCRIPTION
### Description of change

<!-- Please provide a description of the change here. -->

This fixes a number of resource warnings reported by pytest.

One exists in the test suite itself -- an unclosed PEM file -- but the rest are unclosed sockets and SSL sockets that are problems in the package itself.

The warnings shown below are representative:

```
ResourceWarning: unclosed <ssl.SSLSocket ...>
ResourceWarning: unclosed <socket.socket ...>
ResourceWarning: unclosed file <_io.BufferedReader name='dockers/stunnel/keys/server-cert.pem'>
```

> [!NOTE]
>
> This PR DOES NOT resolve all of the warnings that are thrown in the test suite!
>
> There is a lot of work to do on the [test suite's warnings](https://github.com/valkey-io/valkey-py/actions/runs/23520510469/job/68462725179#step:6:443), but this is an initial salvo that resolves the warnings that are displayed when running `make tests` locally.

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

