### PR TITLE
Fix several deprecation warnings

### DIFF
--- a/tests/test_asyncio/test_cluster.py
+++ b/tests/test_asyncio/test_cluster.py
@@ -315,7 +315,8 @@ class TestValkeyClusterObj:
             called += 1
 
         with mock.patch.object(cluster, "aclose", mock_aclose):
-            await cluster.close()
+            with pytest.deprecated_call():
+                await cluster.close()
             assert called == 1
         await cluster.aclose()
 

--- a/tests/test_asyncio/test_cwe_404.py
+++ b/tests/test_asyncio/test_cwe_404.py
@@ -261,4 +261,4 @@ async def test_cluster(master_host):
 
             await asyncio.gather(*[doit() for _ in range(10)])
         finally:
-            await r.close()
+            await r.aclose()

--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -328,7 +328,7 @@ class AbstractConnection:
                 # Use the passed function valkey_connect_func
                 (
                     await self.valkey_connect_func(self)
-                    if asyncio.iscoroutinefunction(self.valkey_connect_func)
+                    if inspect.iscoroutinefunction(self.valkey_connect_func)
                     else self.valkey_connect_func(self)
                 )
         except ValkeyError:


### PR DESCRIPTION
### Description of change

<!-- Please provide a description of the change here. -->

This change fixes several warnings thrown during test suite execution [[recent CI run examples](https://github.com/valkey-io/valkey-py/actions/runs/23879223726/job/69628884559#step:6:299), see the first two warnings]:

```
DeprecationWarning: Call to deprecated close.
(Use aclose() instead) -- Deprecated since version 5.0.0.
```

In one case, the `.close()` usage is incorrect and needed to be updated. In another, the `.close()` call is deliberately testing deprecated usage and simply needed the `pytest.deprecated_call()` context manager added.

```
DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated
and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
```

`inspect.iscoroutinefunction()` was added in Python 3.8 and can be safely switched to.

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

