### PR TITLE
Remove connection_pool from CommandsProtocol to fix type checker false positives

### DIFF
--- a/valkey/typing.py
+++ b/valkey/typing.py
@@ -15,8 +15,6 @@ from typing import (
 
 if TYPE_CHECKING:
     from valkey._parsers import Encoder
-    from valkey.asyncio.connection import ConnectionPool as AsyncConnectionPool
-    from valkey.connection import ConnectionPool
 
 
 Number = Union[int, float]
@@ -54,8 +52,6 @@ ExceptionMappingT = Mapping[str, Union[Type[Exception], Mapping[str, Type[Except
 
 
 class CommandsProtocol(Protocol):
-    connection_pool: Union["AsyncConnectionPool", "ConnectionPool"]
-
     def execute_command(self, *args, **options): ...
 
 

--- a/valkey/typing.py
+++ b/valkey/typing.py
@@ -17,8 +17,6 @@ from typing import (
 
 if TYPE_CHECKING:
     from valkey._parsers import Encoder
-    from valkey.asyncio.connection import ConnectionPool as AsyncConnectionPool
-    from valkey.connection import ConnectionPool
 
 
 class AsyncClientProtocol(Protocol):
@@ -135,8 +133,6 @@ FunctionStatsT = (
 
 
 class CommandsProtocol(Protocol):
-    connection_pool: Union["AsyncConnectionPool", "ConnectionPool"]
-
     def execute_command(self, *args, **options) -> ResponseT: ...
 
 


### PR DESCRIPTION
### Description of change

Remove `connection_pool` from `CommandsProtocol` in `valkey/typing.py`.

`CommandsProtocol` is a structural Protocol used as a base for command mixin classes. It required `connection_pool` as an attribute, but this caused Pyright to report that `ValkeyCluster` cannot be instantiated (abstract class error), because the cluster client does not satisfy the `connection_pool` Protocol requirement statically.

This is a false positive. The code runs correctly at runtime. The fix removes `connection_pool` from the Protocol, keeping only `execute_command` which is what Protocol consumers actually depend on.

Reference: redis/redis-py#3574, redis/redis-py#3656

### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included? (N/A — internal type annotation only)
- [ ] Is there an example added? (N/A)

Fixes #299 