### PR TITLE
Make skip_ifmodversion_lt skip not installed modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,7 +200,7 @@ def skip_ifmodversion_lt(min_version: str, module_name: str):
             check = version < mv
             return pytest.mark.skipif(check, reason="Valkey module version")
 
-    raise AttributeError(f"No valkey module named {module_name}")
+    return pytest.mark.skipif(True, reason=f"No valkey module named {module_name}")
 
 
 def skip_if_nocryptography() -> _TestDecorator:


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

### Description of change

`skip_ifmodversion_lt` should not make a test to fail, if the needed module is not enabled.  Here the marker is updated to skip the test in that case, instead.