### PR TITLE
Fix test_acl_getuser_setuser for newer Valkey versions

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -331,11 +331,17 @@ class TestValkeyCommands:
         assert set(acl["keys"]) == {"~cache:*", "~objects:*"}
         assert len(acl["passwords"]) == 2
         assert set(acl["channels"]) == {"&message:*"}
-        assert_resp_response(
+        assert_resp_response_in(
             r,
             acl["selectors"],
-            [["commands", "-@all +set", "keys", "%W~app*", "channels", ""]],
-            [{"commands": "-@all +set", "keys": "%W~app*", "channels": ""}],
+            [
+                [["commands", "-@all +set", "keys", "%W~app*", "channels", ""]],
+                [["commands", "-@all +set", "keys", "%W~app*", "channels", "", "databases", "alldbs"]],
+            ],
+            [
+                [{"commands": "-@all +set", "keys": "%W~app*", "channels": ""}],
+                [{"commands": "-@all +set", "keys": "%W~app*", "channels": "", "databases": "alldbs"}],
+            ],
         )
 
     @skip_if_server_version_lt("6.0.0")


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

### Description of change

Newer Valkey versions return additional 'databases'/'alldbs' fields in ACL selector responses. Use `assert_resp_response_in` to accept both the old format (without `databases`) and the new format (with `databases: alldbs`).