### PR TITLE
fix(connection): retry entire connect+handshake to fix PubSub reconnect

### DIFF
--- a/valkey/asyncio/connection.py
+++ b/valkey/asyncio/connection.py
@@ -312,7 +312,8 @@ class AbstractConnection:
             return
         try:
             await self.retry.call_with_retry(
-                lambda: self._connect(), lambda error: self.disconnect()
+                lambda: self._connect_with_handshake(),
+                lambda error: self.disconnect(),
             )
         except asyncio.CancelledError:
             raise  # in 3.7 and earlier, this is an Exception, not BaseException
@@ -323,6 +324,28 @@ class AbstractConnection:
         except Exception as exc:
             raise ConnectionError(exc) from exc
 
+        # run any user callbacks. right now the only internal callback
+        # is for pubsub channel/pattern resubscription
+        # first, remove any dead weakrefs
+        self._connect_callbacks = [ref for ref in self._connect_callbacks if ref()]
+        for ref in self._connect_callbacks:
+            callback = ref()
+            task = callback(self)
+            if task and inspect.isawaitable(task):
+                await task
+
+    async def _connect_with_handshake(self):
+        """
+        Establish the socket connection and perform the initial handshake
+        (authentication, protocol negotiation, etc.) as a single retryable unit.
+
+        By combining the socket connect and on_connect handshake into one
+        coroutine, the retry logic covers both steps.  Previously only the
+        socket connect was retried, so a ConnectionError raised inside
+        on_connect (e.g. during PubSub reconnection) would escape the retry
+        scope and crash the caller.
+        """
+        await self._connect()
         try:
             if not self.valkey_connect_func:
                 # Use the default on_connect function
@@ -335,19 +358,10 @@ class AbstractConnection:
                     else self.valkey_connect_func(self)
                 )
         except ValkeyError:
-            # clean up after any error in on_connect
+            # clean up after any error in on_connect so that the next
+            # retry attempt starts from a clean state
             await self.disconnect()
             raise
-
-        # run any user callbacks. right now the only internal callback
-        # is for pubsub channel/pattern resubscription
-        # first, remove any dead weakrefs
-        self._connect_callbacks = [ref for ref in self._connect_callbacks if ref()]
-        for ref in self._connect_callbacks:
-            callback = ref()
-            task = callback(self)
-            if task and inspect.isawaitable(task):
-                await task
 
     @abstractmethod
     async def _connect(self):

--- a/valkey/connection.py
+++ b/valkey/connection.py
@@ -318,26 +318,14 @@ class AbstractConnection:
         if self._sock is not None:
             return
         try:
-            sock = self.retry.call_with_retry(
-                lambda: self._connect(), lambda error: self.disconnect(error)
+            self.retry.call_with_retry(
+                lambda: self._connect_with_handshake(),
+                lambda error: self.disconnect(error),
             )
         except socket.timeout:
             raise TimeoutError("Timeout connecting to server")
         except OSError as e:
             raise ConnectionError(self._error_message(e))
-
-        self._sock = sock
-        try:
-            if self.valkey_connect_func is None:
-                # Use the default on_connect function
-                self.on_connect()
-            else:
-                # Use the passed function valkey_connect_func
-                self.valkey_connect_func(self)
-        except ValkeyError:
-            # clean up after any error in on_connect
-            self.disconnect()
-            raise
 
         # run any user callbacks. right now the only internal callback
         # is for pubsub channel/pattern resubscription
@@ -347,6 +335,32 @@ class AbstractConnection:
             callback = ref()
             if callback:
                 callback(self)
+
+    def _connect_with_handshake(self):
+        """
+        Establish the socket connection and perform the initial handshake
+        (authentication, protocol negotiation, etc.) as a single retryable unit.
+
+        By combining the socket connect and on_connect handshake into one
+        callable, the retry logic covers both steps.  Previously only the
+        socket connect was retried, so a ConnectionError raised inside
+        on_connect (e.g. during PubSub reconnection) would escape the retry
+        scope and crash the caller.
+        """
+        sock = self._connect()
+        self._sock = sock
+        try:
+            if self.valkey_connect_func is None:
+                # Use the default on_connect function
+                self.on_connect()
+            else:
+                # Use the passed function valkey_connect_func
+                self.valkey_connect_func(self)
+        except ValkeyError:
+            # clean up after any error in on_connect so that the next
+            # retry attempt starts from a clean state
+            self.disconnect()
+            raise
 
     @abstractmethod
     def _connect(self):


### PR DESCRIPTION
## Summary

Fixes #169
Related: #225

## Problem

The retry logic in `AbstractConnection.connect()` only wrapped the socket-level `_connect()` call. The `on_connect()` handshake (authentication, protocol negotiation, CLIENT SETNAME, etc.) ran **outside** the retry scope.

When a PubSub connection drops and the client tries to reconnect, `on_connect()` can raise a `ConnectionError` (e.g. `Connection reset by peer` — errno 104) if the server isn't fully ready yet. Because this error escapes the retry block, the configured retry policy is never applied and the PubSub thread crashes instead of recovering.

This is also the root cause of the idle-to-burst `ConnectionError` bursts seen on ElastiCache Serverless (issue #225).

## Fix

Extract a `_connect_with_handshake()` helper that combines the socket connect and `on_connect()` handshake into a single retryable unit. The retry block in `connect()` now covers the full connection establishment flow. On failure, `disconnect()` is called as the error handler to ensure a clean state before the next attempt.

The same fix is applied to both:
- `valkey/connection.py` (sync)
- `valkey/asyncio/connection.py` (async)

## Prior art

This mirrors the fix applied to redis-py in [PR #3863](https://github.com/redis/redis-py/pull/3863), which resolved the equivalent issues in that library.

## Changes

- `valkey/connection.py`: `connect()` now calls `_connect_with_handshake()` inside the retry block; new `_connect_with_handshake()` method combines socket connect + handshake
- `valkey/asyncio/connection.py`: same changes for the async path