### PR TITLE
Relax dependency version constraints for Python 3.10 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ type-check = [
     'libvalkey',
 ]
 docs = [
-    'sphinx>=9.0,<10.0',
+    'sphinx >=8.0,<8.2',
     'docutils',
     'nbsphinx',
     'sphinx-gallery',
@@ -77,7 +77,7 @@ docs = [
 libvalkey = ["libvalkey>=4.0.1"]
 ocsp = [
     "cryptography>=43.0.0",
-    "pyopenssl==23.2.1",
+    "pyopenssl>=23.2.0",
     "requests>=2.31.0",
 ]
 


### PR DESCRIPTION
- Downgrade sphinx from >=9.0,<10.0 to >=8.0,<8.2 (sphinx 8.2+ and 9.x require Python >=3.11, conflicting with requires-python >=3.10)
- Relax pyopenssl from ==23.2.1 to >=23.2.0 (23.2.1 does not exist)

