### PR TITLE
Set timeouts for each CI job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   analyze:
+    timeout-minutes: 5
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -5,5 +5,6 @@ on: [pull_request]
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: tisonkun/actions-dco@v1.1

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,6 +24,7 @@ jobs:
    build-docs:
      name: Build docs
      runs-on: ubuntu-latest
+     timeout-minutes: 5
      steps:
        - uses: actions/checkout@v6
        - uses: actions/setup-python@v6

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -28,6 +28,7 @@ jobs:
    dependency-audit:
      name: Dependency audit
      runs-on: ubuntu-latest
+     timeout-minutes: 5
      steps:
        - uses: actions/checkout@v6
        - uses: pypa/gh-action-pip-audit@v1.1.0
@@ -39,6 +40,7 @@ jobs:
    lint:
      name: Code linters
      runs-on: ubuntu-latest
+     timeout-minutes: 5
      steps:
        - uses: actions/checkout@v6
        - uses: actions/setup-python@v6
@@ -55,6 +57,7 @@ jobs:
     outputs:
       current_date: ${{ steps.date.outputs.current_date }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Set current date
         id: date
@@ -170,6 +173,7 @@ jobs:
    build_and_test_package:
     name: Validate building and installing the package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [run-tests, get-date, populate-cache]
     strategy:
       fail-fast: false
@@ -198,6 +202,7 @@ jobs:
    install_package_from_commit:
     name: Install package from commit hash
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -11,6 +11,7 @@ jobs:
 
   build_and_package:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: pypi
     permissions:
       id-token: write

--- a/.github/workflows/rebase-merge.yml
+++ b/.github/workflows/rebase-merge.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   forbid-merge-commits:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Run Forbid Merge Commits Action
         uses: motlin/forbid-merge-commits-action@main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write  #  to create a github release (release-drafter/release-drafter)
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     environment: release-drafter
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,6 +4,7 @@ on:
 jobs:
   check-spelling:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

The goal of this PR is to prevent any specific job from falling back to [GitHub's default timeout: 360 minutes](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes) (6 hours).

With this change, each job will now timeout after some reasonable number of minutes. The minimum value set in this commit is 5 minutes, but recent runtimes for each job were verified in GitHub to ensure a generous margin before timing out.

For example, "Validate building and installing the package" generally takes about 3.5 minutes,
so its timeout is set to 10 minutes.

This opportunity was discovered when reviewing recent CI runs. For example, the CodeQL workflow usually takes ~1.5 minutes to execute, but has sometimes run far, far longer than expected:

> <img width="1273" height="311" alt="image" src="https://github.com/user-attachments/assets/1e95fbe4-516a-4bff-a0f4-d9b9b0f67531" />

This particular example, from May 5th, might correspond with a GitHub Actions degradation (screenshot from githubstatus.com):

> <img width="476" height="299" alt="image" src="https://github.com/user-attachments/assets/7069636b-cf79-4e1c-8691-cea43618992a" />
