### PR TITLE
Fix CLUSTER MYSHARDID parsing with decode_responses=True

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1183,6 +1183,12 @@ class TestClusterValkeyCommands:
         myshardid = r.cluster_myshardid()
         assert isinstance(myshardid, str)
         assert len(myshardid) > 0
+        
+    def test_parse_cluster_myshardid_handles_decoded_input(self):
+        from valkey.cluster import parse_cluster_myshardid
+        assert parse_cluster_myshardid(b"abc123") == "abc123"
+        # decode_responses=True -> input is already str, must not raise
+        assert parse_cluster_myshardid("abc123") == "abc123"    
 
     def test_cluster_addslots(self, r):
         node = r.get_random_node()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1179,17 +1179,12 @@ class TestClusterValkeyCommands:
                     assert attribute in attributes
 
     @skip_if_server_version_lt("7.2.0")
-    def test_cluster_myshardid(self, r):
-        myshardid = r.cluster_myshardid()
+    @pytest.mark.parametrize("client_fixture_name", ("r", "decoded_r"))
+    def test_cluster_myshardid(self, client_fixture_name, request):
+        client: ValkeyCluster = request.getfixturevalue(client_fixture_name)
+        myshardid = client.cluster_myshardid()
         assert isinstance(myshardid, str)
         assert len(myshardid) > 0
-
-    def test_parse_cluster_myshardid_handles_decoded_input(self):
-        from valkey.cluster import parse_cluster_myshardid
-
-        assert parse_cluster_myshardid(b"abc123") == "abc123"
-        # decode_responses=True -> input is already str, must not raise
-        assert parse_cluster_myshardid("abc123") == "abc123"
 
     def test_cluster_addslots(self, r):
         node = r.get_random_node()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1183,9 +1183,10 @@ class TestClusterValkeyCommands:
         myshardid = r.cluster_myshardid()
         assert isinstance(myshardid, str)
         assert len(myshardid) > 0
-        
+
     def test_parse_cluster_myshardid_handles_decoded_input(self):
         from valkey.cluster import parse_cluster_myshardid
+
         assert parse_cluster_myshardid(b"abc123") == "abc123"
         # decode_responses=True -> input is already str, must not raise
         assert parse_cluster_myshardid("abc123") == "abc123"    

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1189,7 +1189,7 @@ class TestClusterValkeyCommands:
 
         assert parse_cluster_myshardid(b"abc123") == "abc123"
         # decode_responses=True -> input is already str, must not raise
-        assert parse_cluster_myshardid("abc123") == "abc123"    
+        assert parse_cluster_myshardid("abc123") == "abc123"
 
     def test_cluster_addslots(self, r):
         node = r.get_random_node()

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -119,7 +119,7 @@ def parse_cluster_shards(resp, **options):
     return shards
 
 
-def parse_cluster_myshardid(resp, **options):
+def parse_cluster_myshardid(resp: str | bytes, **options: Any) -> str:
     """
     Parse CLUSTER MYSHARDID response.
     """

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -123,7 +123,7 @@ def parse_cluster_myshardid(resp, **options):
     """
     Parse CLUSTER MYSHARDID response.
     """
-    return resp.decode("utf-8")
+    return str_if_bytes(resp)
 
 
 PRIMARY = "primary"


### PR DESCRIPTION
## Summary
`parse_cluster_myshardid` unconditionally calls `resp.decode("utf-8")`.
When the client is created with `decode_responses=True`, the response is
already a `str`, so `cluster_myshardid()` raises
`AttributeError: 'str' object has no attribute 'decode'`.

Fixes #309

## Changes
- `valkey/cluster.py`: use the existing `str_if_bytes` helper (already
  imported in this module) instead of calling `.decode()` directly, so the
  parser works for both `decode_responses=False` (bytes) and
  `decode_responses=True` (str).
- `tests/test_cluster.py`: add a regression test covering both the bytes
  and already-decoded `str` inputs.