### PR TITLE
Add a tox config for local testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,16 @@
 [run]
-source = valkey
+source =
+    valkey
+    tests
+
+relative_files = true
+parallel = true
+branch = true
+
+[paths]
+source =
+    valkey
+    */site-packages
+
+[report]
+skip_covered = true

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@
 services:
 
   valkey:
-    image: valkey/valkey:latest
+    image: valkey/valkey:${VALKEY_DOCKER_TAG:-latest}
     container_name: valkey-standalone
     ports:
       - "6379:6379"
@@ -20,7 +20,7 @@ services:
       - all
 
   replica:
-    image: valkey/valkey:latest
+    image: valkey/valkey:${VALKEY_DOCKER_TAG:-latest}
     container_name: valkey-replica
     depends_on:
       - valkey
@@ -77,7 +77,7 @@ services:
       - "./dockers/stunnel/keys:/etc/stunnel/keys:ro"
 
   sentinel:
-    image: valkey/valkey:latest
+    image: valkey/valkey:${VALKEY_DOCKER_TAG:-latest}
     container_name: valkey-sentinel
     depends_on:
       - valkey
@@ -96,7 +96,7 @@ services:
       - all
 
   sentinel2:
-    image: valkey/valkey:latest
+    image: valkey/valkey:${VALKEY_DOCKER_TAG:-latest}
     container_name: valkey-sentinel2
     depends_on:
       - valkey
@@ -115,7 +115,7 @@ services:
       - all
 
   sentinel3:
-    image: valkey/valkey:latest
+    image: valkey/valkey:${VALKEY_DOCKER_TAG:-latest}
     container_name: valkey-sentinel3
     depends_on:
       - valkey

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import argparse
 import math
+import os
 import time
 from collections.abc import Callable
 from typing import TypeVar
@@ -17,8 +18,8 @@ from valkey.exceptions import ValkeyClusterException
 from valkey.retry import Retry
 
 VALKEY_INFO = {}
-default_valkey_url = "valkey://localhost:6379/0"
-default_protocol = "2"
+default_valkey_url = os.getenv("TARGET_VALKEY_URL", "valkey://localhost:6379/0")
+default_protocol = os.getenv("TARGET_RESP_PROTOCOL", "2")
 default_valkeymod_url = "valkey://localhost:6379"
 
 # default ssl client ignores verification for the purpose of testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,132 @@
+[tox]
+env_list =
+    start_containers
+    coverage-erase
+
+    # IF YOU NEED TO EDIT THIS LINE, USE SEARCH-AND-REPLACE!
+    # Changes MUST be replicated to all locations in this file.
+    {py3.10, py3.11, py3.12, py3.13, py3.14, pypy3.10, pypy3.11}-{standalone, cluster}-resp{2, 3}-{plain, libvalkey}
+
+    coverage-combine
+    coverage-html
+    stop_containers
+
+    # IF YOU NEED TO EDIT THIS LINE, USE SEARCH-AND-REPLACE!
+    # Changes MUST be replicated to all locations in this file.
+    mypy-py{3.10, 3.11, 3.12, 3.13, 3.14}
+
+    docs
+    build{, -minimum}
+
+[testenv]
+package = wheel
+wheel_build_env = build_wheel
+
+
+[testenv:start_containers]
+description = Start the Docker containers
+skip_install = true
+allowlist_externals =
+    bash
+    docker
+pass_env =
+    VALKEY_DOCKER_TAG
+commands =
+    docker compose --profile all up --wait
+
+
+[testenv:{py3.10, py3.11, py3.12, py3.13, py3.14, pypy3.10, pypy3.11}-{standalone, cluster}-resp{2, 3}-{plain, libvalkey}]
+description = Test the code on Python {py_dot_ver}
+dependency_groups =
+    dev
+extras =
+    libvalkey: libvalkey
+depends =
+    start_containers
+    coverage-erase
+set_env =
+    # `--protocol` equivalents
+    resp2:      TARGET_RESP_PROTOCOL=2
+    resp3:      TARGET_RESP_PROTOCOL=3
+    # `--valkey-url` equivalents
+    standalone: TARGET_VALKEY_URL=valkey://localhost:6379/0
+    cluster:    TARGET_VALKEY_URL=valkey://localhost:16379/0
+commands =
+    standalone: coverage run -m pytest -v -m 'not onlycluster' -W all {posargs}
+    cluster:    coverage run -m pytest -v -m 'not onlynoncluster and not valkeymod' -W all {posargs}
+
+
+[testenv:stop_containers]
+description = Stop the Docker containers
+skip_install = true
+allowlist_externals =
+    docker
+commands =
+    docker compose --profile all down
+depends =
+    {py3.10, py3.11, py3.12, py3.13, py3.14, pypy3.10, pypy3.11}-{standalone, cluster}-resp{2, 3}-{plain, libvalkey}
+
+
+[testenv:coverage_base]
+description = Base config for coverage-* environments
+deps =
+    coverage
+
+[testenv:coverage-erase]
+description = Erase coverage data files
+base = coverage_base
+commands =
+    - coverage erase
+
+[testenv:coverage-combine]
+description = Combine all coverage files
+base = coverage_base
+depends =
+    {py3.10, py3.11, py3.12, py3.13, py3.14, pypy3.10, pypy3.11}-{standalone, cluster}-resp{2, 3}-{plain, libvalkey}
+commands =
+    - coverage combine
+
+[testenv:coverage-html]
+description = Create an HTML coverage report
+base = coverage_base
+depends =
+    coverage-combine
+commands =
+    coverage html
+
+[testenv:mypy-py{3.10, 3.11, 3.12, 3.13, 3.14}]
+description = Test type annotations on Python {py_dot_ver}
+skip_install = true
+deps =
+    mypy
+    types-requests
+    cryptography
+    libvalkey
+commands =
+    mypy
+
+[testenv:docs]
+description = Test building the documentation
+base_python = py3.13
+skip_install = true
+dependency_groups =
+    docs
+commands =
+    sphinx-build -b html docs docs/_build/html
+
+[testenv:build{,-minimum}]
+description =
+    Test building the project
+    minimum: (minimum requirements)
+base_python =
+    minimum: py3.10
+skip_install = true
+recreate = true
+deps =
+    build
+    twine
+    minimum: hatchling==0.8.0
+    !minimum: hatchling
+commands =
+    python -m build --outdir {envdir}/dist/ --no-isolation
+    twine check --strict {envdir}/dist/*


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

This PR introduces the following changes related to running the test suite on a developer PC:

* Add a tox config for local testing.

  This includes running all variations of the test suite,
  testing type annotations on all supported Python versions,
  testing documentation builds, testing package builds,
  and generating a coverage HTML report.

* Allow the Valkey server version to be specified by Docker tag.

  This is configured using an environment variable
  named `VALKEY_DOCKER_TAG`.

* Allow the Valkey URL and protocol version to be specified
  using `TEST_URL` and `TEST_PROTOCOL` environment variables,
  respectively.

* Configure coverage to collect coverage per test suite run
  in separate files, and to collect branch coverage.

Introducing this tox config allows me to perform significantly more thorough and granular testing locally.