### PR TITLE
Remove testing using uvloop

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -153,9 +153,6 @@ jobs:
            fi
            make devenv
            make ${{matrix.test-type}}-tests PROTOCOL=${{ matrix.protocol-version }}
-           if [[ "${{matrix.python-version}}" != pypy-* ]]; then
-            make ${{matrix.test-type}}-tests USE_UVLOOP=1 PROTOCOL=${{ matrix.protocol-version }}
-           fi
 
        - uses: actions/upload-artifact@v7
          if: success() || failure()

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,6 @@
-USE_UVLOOP             ?= 0
 PROTOCOL               ?= 2
 CLUSTER_URL            ?= valkey://localhost:16379/0
 ADDITIONAL_PYTEST_ARGS ?=
-
-ifeq ($(USE_UVLOOP), 1)
-	UVLOOP_ARG          := --uvloop
-	UVLOOP_REPORT_INFIX := -uvloop
-else
-	UVLOOP_ARG          := --no-uvloop
-endif
 
 .PHONY: devenv stop-devenv build-docs linters standalone-tests cluster-tests all-tests clean package
 
@@ -65,8 +57,8 @@ standalone-tests: .check-virtualenv
 		--cov-report=xml:coverage_valkey.xml \
 		-W always \
 		-m 'not onlycluster' \
-		--junit-xml=standalone$(UVLOOP_REPORT_INFIX)-results.xml \
-		$(UVLOOP_ARG) $(ADDITIONAL_PYTEST_ARGS)
+		--junit-xml=standalone-results.xml \
+		$(ADDITIONAL_PYTEST_ARGS)
 
 cluster-tests: .check-virtualenv
 	pytest \
@@ -76,8 +68,8 @@ cluster-tests: .check-virtualenv
 		-W always \
 		-m 'not onlynoncluster and not valkeymod' \
 		--valkey-url=$(CLUSTER_URL) \
-		--junit-xml=cluster$(UVLOOP_REPORT_INFIX)-results.xml \
-		$(UVLOOP_ARG) $(ADDITIONAL_PYTEST_ARGS)
+		--junit-xml=cluster-results.xml \
+		$(ADDITIONAL_PYTEST_ARGS)
 
 package: .check-virtualenv
 	hatchling build

--- a/benchmarks/cluster_async.py
+++ b/benchmarks/cluster_async.py
@@ -4,7 +4,6 @@ import time
 
 import aiovalkey_cluster
 import avalkey
-import uvloop
 
 import valkey.asyncio as valkeypy
 
@@ -201,7 +200,7 @@ async def run(client, gather):
         print(await lpop(client, gather))
 
 
-async def main(loop, gather=None):
+async def main(gather=None):
     arc = avalkey.StrictValkeyCluster(
         host=host,
         port=port,
@@ -215,7 +214,7 @@ async def main(loop, gather=None):
         max_idle_time=count,
         idle_check_interval=count,
     )
-    print(f"{loop} {gather} {await warmup(arc)} avalkey")
+    print(f"{gather} {await warmup(arc)} avalkey")
     print(await run(arc, gather=gather))
     arc.connection_pool.disconnect()
 
@@ -226,7 +225,7 @@ async def main(loop, gather=None):
         idle_connection_timeout=count,
         pool_maxsize=2**31,
     )
-    print(f"{loop} {gather} {await warmup(aiorc)} aiovalkey-cluster")
+    print(f"{gather} {await warmup(aiorc)} aiovalkey-cluster")
     print(await run(aiorc, gather=gather))
     aiorc.close()
     await aiorc.wait_closed()
@@ -240,7 +239,7 @@ async def main(loop, gather=None):
         decode_responses=False,
         max_connections=2**31,
     ) as rca:
-        print(f"{loop} {gather} {await warmup(rca)} valkeypy")
+        print(f"{gather} {await warmup(rca)} valkeypy")
         print(await run(rca, gather=gather))
 
 
@@ -252,12 +251,6 @@ if __name__ == "__main__":
     count = 10000
     size = 256
 
-    asyncio.run(main("asyncio"))
-    asyncio.run(main("asyncio", gather=False))
-    asyncio.run(main("asyncio", gather=True))
-
-    uvloop.install()
-
-    asyncio.run(main("uvloop"))
-    asyncio.run(main("uvloop", gather=False))
-    asyncio.run(main("uvloop", gather=True))
+    asyncio.run(main())
+    asyncio.run(main(gather=False))
+    asyncio.run(main(gather=True))

--- a/benchmarks/cluster_async_pipeline.py
+++ b/benchmarks/cluster_async_pipeline.py
@@ -4,7 +4,6 @@ import time
 
 import aiovalkey_cluster
 import avalkey
-import uvloop
 
 import valkey.asyncio as valkeypy
 
@@ -49,7 +48,7 @@ async def run(client):
             )
 
 
-async def main(loop):
+async def main():
     arc = avalkey.StrictValkeyCluster(
         host=host,
         port=port,
@@ -63,7 +62,7 @@ async def main(loop):
         max_idle_time=count,
         idle_check_interval=count,
     )
-    print(f"{loop} {await warmup(arc)} avalkey")
+    print(f"{await warmup(arc)} avalkey")
     print(await run(arc))
     arc.connection_pool.disconnect()
 
@@ -74,7 +73,7 @@ async def main(loop):
         idle_connection_timeout=count,
         pool_maxsize=2**31,
     )
-    print(f"{loop} {await warmup(aiorc)} aiovalkey-cluster")
+    print(f"{await warmup(aiorc)} aiovalkey-cluster")
     print(await run(aiorc))
     aiorc.close()
     await aiorc.wait_closed()
@@ -88,7 +87,7 @@ async def main(loop):
         decode_responses=False,
         max_connections=2**31,
     ) as rca:
-        print(f"{loop} {await warmup(rca)} valkeypy")
+        print(f"{await warmup(rca)} valkeypy")
         print(await run(rca))
 
 
@@ -100,8 +99,4 @@ if __name__ == "__main__":
     count = 10000
     size = 256
 
-    asyncio.run(main("asyncio"))
-
-    uvloop.install()
-
-    asyncio.run(main("uvloop"))
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ dev = [
     'pytest-cov',
     'pytest-timeout',
     'ujson>=4.2.0',
-    'uvloop; implementation_name != "pypy"',
     'vulture>=2.3.0',
 ]
 type-check = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import argparse
 import math
 import time
 from collections.abc import Callable
@@ -60,10 +59,6 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        "--uvloop", action=argparse.BooleanOptionalAction, help="Run tests with uvloop"
-    )
-
-    parser.addoption(
         "--sentinels",
         action="store",
         default="localhost:26379,localhost:26380,localhost:26381",
@@ -114,16 +109,6 @@ def pytest_sessionstart(session):
     if cluster_enabled:
         cluster_nodes = session.config.getoption("--valkey-cluster-nodes")
         wait_for_cluster_creation(valkey_url, cluster_nodes)
-
-    use_uvloop = session.config.getoption("--uvloop")
-
-    if use_uvloop:
-        try:
-            import uvloop
-
-            uvloop.install()
-        except ImportError as e:
-            raise RuntimeError("Cannot import uvloop, make sure it is installed") from e
 
 
 def wait_for_cluster_creation(valkey_url, cluster_nodes, timeout=60):


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

This commit removes uvloop completely from valkey-py.

uvloop is being used exclusively in the test suite and in some benchmarking code.
However, its use incurs some costs:

* The test suite is being run twice in CI -- once without uvloop, and again with uvloop.
* When uvloop is used in the test suite, it throws deprecation warnings.

  Some warnings come from uvloop's own Python code when running on Python 3.14 and are due to upcoming Python 3.16 removals. Other warnings are from valkey-py's deprecated usage of uvloop.

To reduce test suite execution times,
and to reduce the burden of maintaining uvloop usage, uvloop is completely removed from the project.

When comparing [a CI run with this change](https://github.com/kurtmckee/pr-valkey-py/actions/runs/28170440039/usage) against [a recent scheduled CI run](https://github.com/valkey-io/valkey-py/actions/runs/28069029349/usage), the change is apparent:

| CI run | Wall clock time ("Duration") | Total run time |
|--------|--------|--------|
| `main` | `35m  4s` |  `5h 38m 28s` |
| This change | `30m 40s` | `4h 15m  8s` |
