### PR TITLE
Type annotate `valkey.utils`

### DIFF
--- a/valkey/__init__.py
+++ b/valkey/__init__.py
@@ -33,7 +33,6 @@ from valkey.sentinel import (
     SentinelManagedConnection,
     SentinelManagedSSLConnection,
 )
-from valkey.utils import from_url
 
 
 def int_or_str(value):
@@ -50,6 +49,8 @@ Redis = Valkey
 StrictRedis = StrictValkey
 RedisCluster = ValkeyCluster
 RedisError = ValkeyError
+
+from_url = Valkey.from_url
 
 
 __all__ = [

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -36,7 +36,6 @@ from valkey.retry import Retry
 from valkey.utils import (
     LIBVALKEY_AVAILABLE,
     dict_merge,
-    list_keys_to_dict,
     merge_result,
     safe_str,
     str_if_bytes,
@@ -217,7 +216,7 @@ class AbstractValkeyCluster:
     NODE_FLAGS = {PRIMARIES, REPLICAS, ALL_NODES, RANDOM, DEFAULT_NODE}
 
     COMMAND_FLAGS = dict_merge(
-        list_keys_to_dict(
+        dict.fromkeys(
             [
                 "ACL CAT",
                 "ACL DELUSER",
@@ -305,7 +304,7 @@ class AbstractValkeyCluster:
             ],
             DEFAULT_NODE,
         ),
-        list_keys_to_dict(
+        dict.fromkeys(
             [
                 "FLUSHALL",
                 "FLUSHDB",
@@ -322,8 +321,8 @@ class AbstractValkeyCluster:
             ],
             PRIMARIES,
         ),
-        list_keys_to_dict(["FUNCTION DUMP"], RANDOM),
-        list_keys_to_dict(
+        dict.fromkeys(["FUNCTION DUMP"], RANDOM),
+        dict.fromkeys(
             [
                 "CLUSTER COUNTKEYSINSLOT",
                 "CLUSTER DELSLOTS",
@@ -378,14 +377,12 @@ class AbstractValkeyCluster:
     }
 
     RESULT_CALLBACKS = dict_merge(
-        list_keys_to_dict(["PUBSUB NUMSUB", "PUBSUB SHARDNUMSUB"], parse_pubsub_numsub),
-        list_keys_to_dict(
-            ["PUBSUB NUMPAT"], lambda command, res: sum(list(res.values()))
-        ),
-        list_keys_to_dict(
+        dict.fromkeys(["PUBSUB NUMSUB", "PUBSUB SHARDNUMSUB"], parse_pubsub_numsub),
+        dict.fromkeys(["PUBSUB NUMPAT"], lambda command, res: sum(list(res.values()))),
+        dict.fromkeys(
             ["KEYS", "PUBSUB CHANNELS", "PUBSUB SHARDCHANNELS"], merge_result
         ),
-        list_keys_to_dict(
+        dict.fromkeys(
             [
                 "PING",
                 "CONFIG SET",
@@ -401,21 +398,19 @@ class AbstractValkeyCluster:
             ],
             lambda command, res: all(res.values()) if isinstance(res, dict) else res,
         ),
-        list_keys_to_dict(
+        dict.fromkeys(
             ["DBSIZE", "WAIT"],
             lambda command, res: sum(res.values()) if isinstance(res, dict) else res,
         ),
-        list_keys_to_dict(
+        dict.fromkeys(
             ["CLIENT UNBLOCK"], lambda command, res: 1 if sum(res.values()) > 0 else 0
         ),
-        list_keys_to_dict(["SCAN"], parse_scan_result),
-        list_keys_to_dict(
-            ["SCRIPT LOAD"], lambda command, res: list(res.values()).pop()
-        ),
-        list_keys_to_dict(
+        dict.fromkeys(["SCAN"], parse_scan_result),
+        dict.fromkeys(["SCRIPT LOAD"], lambda command, res: list(res.values()).pop()),
+        dict.fromkeys(
             ["SCRIPT EXISTS"], lambda command, res: [all(k) for k in zip(*res.values())]
         ),
-        list_keys_to_dict(["SCRIPT FLUSH"], lambda command, res: all(res.values())),
+        dict.fromkeys(["SCRIPT FLUSH"], lambda command, res: all(res.values())),
     )
 
     ERRORS_ALLOW_RETRY = (ConnectionError, TimeoutError, ClusterDownError)

--- a/valkey/utils.py
+++ b/valkey/utils.py
@@ -1,7 +1,6 @@
 import logging
-from contextlib import contextmanager
 from functools import wraps
-from typing import Any, Dict, Mapping, Union
+from typing import Any, Callable, Iterable, TypeVar, overload
 
 try:
     import libvalkey  # noqa
@@ -27,37 +26,28 @@ except ImportError:
 
 from importlib import metadata
 
-
-def from_url(url, **kwargs):
-    """
-    Returns an active Valkey client generated from the given database URL.
-
-    Will attempt to extract the database id from the path url fragment, if
-    none is provided.
-    """
-    from valkey.client import Valkey
-
-    return Valkey.from_url(url, **kwargs)
+T = TypeVar("T")
 
 
-@contextmanager
-def pipeline(valkey_obj):
-    p = valkey_obj.pipeline()
-    yield p
-    p.execute()
+@overload
+def str_if_bytes(value: bytes) -> str: ...
 
 
-def str_if_bytes(value: Union[str, bytes]) -> str:
+@overload
+def str_if_bytes(value: T) -> T: ...
+
+
+def str_if_bytes(value: bytes | T) -> str | T:
     return (
         value.decode("utf-8", errors="replace") if isinstance(value, bytes) else value
     )
 
 
-def safe_str(value):
+def safe_str(value: Any) -> str:
     return str(str_if_bytes(value))
 
 
-def dict_merge(*dicts: Mapping[str, Any]) -> Dict[str, Any]:
+def dict_merge(*dicts: dict[str, Any]) -> dict[str, Any]:
     """
     Merge all provided dicts into 1 dict.
     *dicts : `dict`
@@ -71,11 +61,7 @@ def dict_merge(*dicts: Mapping[str, Any]) -> Dict[str, Any]:
     return merged
 
 
-def list_keys_to_dict(key_list, callback):
-    return dict.fromkeys(key_list, callback)
-
-
-def merge_result(command, res):
+def merge_result(command: Any, res: dict[Any, Iterable[T]]) -> list[T]:
     """
     Merge all items in `res` into a list.
 
@@ -93,7 +79,12 @@ def merge_result(command, res):
     return list(result)
 
 
-def warn_deprecated(name, reason="", version="", stacklevel=2):
+def warn_deprecated(
+    name: str,
+    reason: str = "",
+    version: str = "",
+    stacklevel: int = 2,
+) -> None:
     import warnings
 
     msg = f"Call to deprecated {name}."
@@ -104,14 +95,18 @@ def warn_deprecated(name, reason="", version="", stacklevel=2):
     warnings.warn(msg, category=DeprecationWarning, stacklevel=stacklevel)
 
 
-def deprecated_function(reason="", version="", name=None):
+def deprecated_function(
+    reason: str = "",
+    version: str = "",
+    name: str | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """
     Decorator to mark a function as deprecated.
     """
 
-    def decorator(func):
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: dict[str, Any]) -> T:
             warn_deprecated(name or func.__name__, reason, version, stacklevel=3)
             return func(*args, **kwargs)
 
@@ -120,7 +115,7 @@ def deprecated_function(reason="", version="", name=None):
     return decorator
 
 
-def _set_info_logger():
+def _set_info_logger() -> None:
     """
     Set up a logger that log info logs to stdout.
     (This is used by the default push response handler)
@@ -133,7 +128,7 @@ def _set_info_logger():
         logger.addHandler(handler)
 
 
-def get_lib_version():
+def get_lib_version() -> str:
     try:
         libver = metadata.version("valkey")
     except metadata.PackageNotFoundError:


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

This PR adds type annotations to `valkey.utils`. During this work, several functions were found to be unnecessary:

* The `pipeline()` context manager is not used anywhere in the codebase and is not documented anywhere. Rather than trying to add type annotations, it has been removed.
* `list_keys_to_dict()` is an unnecessary pass-through function to `dict.fromkeys()`. Rather than trying to add type annotations, it has been removed.
* `from_url()` is a pass-through function to `Valkey.from_url()`, but it creates a circular import. Its definition has been moved to `valkey/__init__.py`.

Running `mypy --strict` shows that there are no remaining errors in `valkey.utils`.