### PR TITLE
Fix a "title underline too short" doc build warning

### DIFF
--- a/docs/connections.rst
+++ b/docs/connections.rst
@@ -8,7 +8,7 @@ Generic Client
 This is the client used to connect directly to a standard Valkey node.
 
 Standalone replica redirect capability
-=====================================
+======================================
 
 Valkey 8.0 adds ``CLIENT CAPA redirect`` for standalone primary/replica
 deployments. In valkey-py, this is exposed as the opt-in


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

Fix a doc build warning:

```
docs/connections.rst:11: WARNING: Title underline too short.

Standalone replica redirect capability
===================================== [docutils]
```
