### PR TITLE
Begin type-checking `valkey._parsers`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,12 @@ packages = ["valkey"]
 sqlite_cache = true
 
 [[tool.mypy.overrides]]
-# The goal is to eliminate the `tool.mypy.overrides` section.
+# The goal is to eliminate the `tool.mypy.overrides` sections.
 # This will be accomplished by resolving type annotation issues
 # in the modules listed below.
+#
+# Type checking may be re-enabled for specific submodules
+# in a second "overrides" section, below.
 ignore_errors = true
 module = [
     "valkey.client",
@@ -128,4 +131,16 @@ module = [
     "valkey.commands.*",
     "valkey.asyncio.*",
     "valkey._parsers.*",
+]
+
+
+[[tool.mypy.overrides]]
+# This config section re-enables type-checking for submodules.
+# For example, if all submodules in "valkey.x.*" are disabled above,
+# this section might re-enable type-checking for "valkey.x.foo"
+# as type annotations are added, corrected, and tested
+# in "valkey.x.*", submodule by submodule.
+ignore_errors = false
+module = [
+    "valkey._parsers.encoders",
 ]

--- a/valkey/_parsers/encoders.py
+++ b/valkey/_parsers/encoders.py
@@ -1,4 +1,14 @@
+from __future__ import annotations
+
+import sys
+from typing import Any, Literal, overload
+
 from ..exceptions import DataError
+
+if sys.version_info >= (3, 11):
+    from typing import Never
+else:
+    from typing_extensions import Never
 
 
 class Encoder:
@@ -6,12 +16,33 @@ class Encoder:
 
     __slots__ = "encoding", "encoding_errors", "decode_responses"
 
-    def __init__(self, encoding, encoding_errors, decode_responses):
+    def __init__(
+        self,
+        encoding: str,
+        encoding_errors: (
+            Literal["ignore", "replace", "strict", "xmlcharrefreplace"] | str
+        ),
+        decode_responses: bool,
+    ) -> None:
         self.encoding = encoding
         self.encoding_errors = encoding_errors
         self.decode_responses = decode_responses
 
-    def encode(self, value):
+    @overload
+    def encode(self, value: memoryview[bytes]) -> memoryview[bytes]: ...
+
+    @overload
+    def encode(self, value: bool) -> Never: ...
+
+    @overload
+    def encode(self, value: bytes | int | float | str) -> bytes: ...
+
+    @overload
+    def encode(self, value: Any) -> Never: ...
+
+    def encode(
+        self, value: bytes | memoryview[bytes] | int | float | str
+    ) -> bytes | memoryview[bytes]:
         "Return a bytestring or bytes-like representation of the value"
         if isinstance(value, (bytes, memoryview)):
             return value
@@ -34,7 +65,25 @@ class Encoder:
             value = value.encode(self.encoding, self.encoding_errors)
         return value
 
-    def decode(self, value, force=False):
+    @overload
+    def decode(
+        self,
+        value: bytes | memoryview[bytes] | str,
+        force: Literal[True],
+    ) -> str: ...
+
+    @overload
+    def decode(
+        self,
+        value: bytes | memoryview[bytes] | str,
+        force: Literal[False],
+    ) -> bytes | memoryview[bytes] | str: ...
+
+    def decode(
+        self,
+        value: bytes | memoryview[bytes] | str,
+        force: bool = False,
+    ) -> Any:
         "Return a unicode string from the bytes-like representation"
         if self.decode_responses or force:
             if isinstance(value, memoryview):


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

This PR introduces the following changes:

* Configure mypy to enable type-checking of `valkey._parsers.encoders`
* Fully type-annotate `valkey._parsers.encoders`

Running `mypy --strict` shows that there are no remaining errors in the `valkey._parsers.encoders` module.
