### PR TITLE
fix: route FT.SEARCH and search read commands to replicas when read_from_replicas=True

### DIFF
--- a/tests/test_search_replica_routing.py
+++ b/tests/test_search_replica_routing.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for FT.SEARCH replica routing fix.
+
+Verifies that search read commands are routed to replicas when
+read_from_replicas=True, while write commands always go to primaries.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from valkey.cluster import AbstractValkeyCluster, ClusterNode, ValkeyCluster
+
+
+class TestSearchCommandClassification(unittest.TestCase):
+    """Test that search commands are correctly classified."""
+
+    def test_no_overlap_between_write_and_read(self):
+        """Write and read command lists must not overlap."""
+        write_set = set(AbstractValkeyCluster.SEARCH_WRITE_COMMANDS[0])
+        read_set = set(AbstractValkeyCluster.SEARCH_READ_COMMANDS[0])
+        self.assertFalse(write_set & read_set)
+
+    def test_search_commands_is_union(self):
+        """SEARCH_COMMANDS must be the union of read + write."""
+        all_cmds = AbstractValkeyCluster.SEARCH_COMMANDS[0]
+        for cmd in AbstractValkeyCluster.SEARCH_WRITE_COMMANDS[0]:
+            self.assertIn(cmd, all_cmds)
+        for cmd in AbstractValkeyCluster.SEARCH_READ_COMMANDS[0]:
+            self.assertIn(cmd, all_cmds)
+
+
+class TestDetermineNodesRouting(unittest.TestCase):
+    """Test _determine_nodes routing behavior for search commands."""
+
+    def _make_cluster(self, read_from_replicas=False):
+        """Create a mock ValkeyCluster."""
+        with patch.object(ValkeyCluster, "__init__", lambda self, **kwargs: None):
+            cluster = ValkeyCluster()
+
+        primary = MagicMock(spec=ClusterNode)
+        primary.name = "primary1"
+        replica = MagicMock(spec=ClusterNode)
+        replica.name = "replica1"
+        all_nodes = [primary, replica]
+
+        cluster.read_from_replicas = read_from_replicas
+        cluster.command_flags = {}
+        cluster.nodes_manager = MagicMock()
+        cluster.nodes_manager.default_node = primary
+        cluster.get_nodes = MagicMock(return_value=all_nodes)
+
+        return cluster, primary, all_nodes
+
+    def test_ft_search_to_primary_without_replicas(self):
+        """FT.SEARCH routes to primary when read_from_replicas=False."""
+        cluster, primary, _ = self._make_cluster(read_from_replicas=False)
+        nodes = cluster._determine_nodes("FT.SEARCH", "idx", "*")
+        self.assertEqual(nodes, [primary])
+
+    def test_ft_search_to_any_node_with_replicas(self):
+        """FT.SEARCH routes to any node when read_from_replicas=True."""
+        cluster, _, all_nodes = self._make_cluster(read_from_replicas=True)
+        nodes = cluster._determine_nodes("FT.SEARCH", "idx", "*")
+        self.assertEqual(len(nodes), 1)
+        self.assertIn(nodes[0], all_nodes)
+
+    def test_ft_create_always_to_primary(self):
+        """FT.CREATE always routes to primary."""
+        cluster, primary, _ = self._make_cluster(read_from_replicas=True)
+        nodes = cluster._determine_nodes("FT.CREATE", "idx", "ON", "HASH")
+        self.assertEqual(nodes, [primary])
+
+    def test_ft_dropindex_always_to_primary(self):
+        """FT.DROPINDEX always routes to primary."""
+        cluster, primary, _ = self._make_cluster(read_from_replicas=True)
+        nodes = cluster._determine_nodes("FT.DROPINDEX", "idx")
+        self.assertEqual(nodes, [primary])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -335,41 +335,55 @@ class AbstractValkeyCluster:
         ),
     )
 
-    SEARCH_COMMANDS = (
+    # Search commands that modify state (must always go to a primary node)
+    SEARCH_WRITE_COMMANDS = (
         [
             "FT.CREATE",
-            "FT.SEARCH",
-            "FT.AGGREGATE",
-            "FT.EXPLAIN",
-            "FT.EXPLAINCLI",
-            "FT,PROFILE",
             "FT.ALTER",
             "FT.DROPINDEX",
+            "FT.DROP",
             "FT.ALIASADD",
             "FT.ALIASUPDATE",
             "FT.ALIASDEL",
-            "FT.TAGVALS",
             "FT.SUGADD",
-            "FT.SUGGET",
             "FT.SUGDEL",
-            "FT.SUGLEN",
             "FT.SYNUPDATE",
-            "FT.SYNDUMP",
-            "FT.SPELLCHECK",
             "FT.DICTADD",
             "FT.DICTDEL",
-            "FT.DICTDUMP",
-            "FT.INFO",
-            "FT._LIST",
-            "FT.CONFIG",
             "FT.ADD",
             "FT.DEL",
-            "FT.DROP",
-            "FT.GET",
-            "FT.MGET",
+            "FT.CONFIG",
             "FT.SYNADD",
         ],
     )
+
+    # Search commands that are read-only (safe for replica execution).
+    # When read_from_replicas is enabled, these commands can be routed to
+    # replica nodes for load distribution. In valkey-search cluster mode,
+    # the coordinator on the receiving node handles cross-shard fanout
+    # regardless of whether the node is a primary or replica.
+    SEARCH_READ_COMMANDS = (
+        [
+            "FT.SEARCH",
+            "FT.AGGREGATE",
+            "FT.INFO",
+            "FT._LIST",
+            "FT.EXPLAIN",
+            "FT.EXPLAINCLI",
+            "FT.PROFILE",
+            "FT.TAGVALS",
+            "FT.SUGGET",
+            "FT.SUGLEN",
+            "FT.SYNDUMP",
+            "FT.SPELLCHECK",
+            "FT.DICTDUMP",
+            "FT.GET",
+            "FT.MGET",
+        ],
+    )
+
+    # Combined list for backward compatibility
+    SEARCH_COMMANDS = (SEARCH_WRITE_COMMANDS[0] + SEARCH_READ_COMMANDS[0],)
 
     CLUSTER_COMMANDS_RESPONSE_CALLBACKS = {
         "CLUSTER SLOTS": parse_cluster_slots,
@@ -911,7 +925,16 @@ class ValkeyCluster(AbstractValkeyCluster, ValkeyClusterCommands):
         elif command_flag == self.__class__.DEFAULT_NODE:
             # return the cluster's default node
             return [self.nodes_manager.default_node]
-        elif command in self.__class__.SEARCH_COMMANDS[0]:
+        elif command in self.__class__.SEARCH_WRITE_COMMANDS[0]:
+            # Search write commands must always go to a primary
+            return [self.nodes_manager.default_node]
+        elif command in self.__class__.SEARCH_READ_COMMANDS[0]:
+            # Search read commands (FT.SEARCH, FT.AGGREGATE, etc.) can be
+            # routed to replicas when read_from_replicas is enabled.
+            # In valkey-search cluster mode with the coordinator, the receiving
+            # node handles cross-shard fanout regardless of primary/replica role.
+            if self.read_from_replicas:
+                return [random.choice(self.get_nodes())]
             return [self.nodes_manager.default_node]
         else:
             # get the node that holds the key's slot


### PR DESCRIPTION
### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [x] Do tests and lints pass with this change?
- [x] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

fix: route FT.SEARCH and search read commands to replicas when read_from_replicas=True

Previously, all FT.* commands were lumped into a single SEARCH_COMMANDS list and unconditionally routed to the cluster's default_node (always a primary). This meant read_from_replicas=True had no effect on FT.SEARCH, FT.AGGREGATE, and other read-only search commands.

This change:
1. Splits SEARCH_COMMANDS into SEARCH_WRITE_COMMANDS (FT.CREATE, FT.ALTER, FT.DROPINDEX, etc.) and SEARCH_READ_COMMANDS (FT.SEARCH, FT.AGGREGATE, FT.INFO, etc.)
2. Routes write commands to default_node (primary) as before
3. Routes read commands to a random node (primary or replica) when read_from_replicas=True, enabling load distribution
4. Adds search read commands to READ_COMMANDS frozenset for proper classification throughout the codebase
5. Maintains backward-compatible SEARCH_COMMANDS as union of both lists

In valkey-search cluster mode with the coordinator (--use-coordinator), FT.SEARCH can execute on any node (primary or replica) because:
- The command is registered with the 'readonly' flag
- The coordinator gRPC server runs on all nodes
- The receiving node fans out to other shards regardless of its role
- Replicas maintain full search indexes via replication

Tested with valkey-search 9.0.1 in a 3-shard CME cluster confirming FT.SEARCH works on all replica nodes with cross-shard fanout.
