### PR TITLE
Fix flaky test_bgsave

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -438,6 +438,19 @@ def wait_for_command(client, monitor, command, key=None):
             return None
 
 
+def wait_for_condition(
+    predicate: Callable[[], object], timeout: float = 10, interval: float = 0.1
+) -> None:
+    """Poll ``predicate`` until it returns a truthy value or ``timeout`` seconds
+    elapse. Raises AssertionError on timeout."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if predicate():
+            return
+        assert time.monotonic() < deadline, "timed out waiting for condition"
+        time.sleep(interval)
+
+
 def is_resp2_connection(r):
     if isinstance(r, valkey.Valkey) or isinstance(r, valkey.asyncio.Valkey):
         protocol = r.connection_pool.connection_kwargs.get("protocol")

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -50,6 +50,7 @@ from .conftest import (
     skip_if_version_is_one_of,
     skip_unless_arch_bits,
     wait_for_command,
+    wait_for_condition,
 )
 
 default_host = "127.0.0.1"
@@ -1455,7 +1456,11 @@ class TestClusterValkeyCommands:
 
     def test_bgsave(self, r):
         assert r.bgsave()
-        sleep(0.3)
+        # Wait for the first bgsave to finish
+        wait_for_condition(
+            lambda: r.info("persistence")["rdb_bgsave_in_progress"] == 0,
+            timeout=10,
+        )
         assert r.bgsave(True)
 
     def test_info(self, r):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,6 +33,7 @@ from .conftest import (
     skip_if_server_version_gte,
     skip_if_server_version_lt,
     skip_unless_arch_bits,
+    wait_for_condition,
 )
 
 
@@ -987,7 +988,11 @@ class TestValkeyCommands:
 
     def test_bgsave(self, r):
         assert r.bgsave()
-        time.sleep(0.3)
+        # Wait for the first bgsave to finish
+        wait_for_condition(
+            lambda: r.info("persistence")["rdb_bgsave_in_progress"] == 0,
+            timeout=10,
+        )
         assert r.bgsave(True)
 
     def test_never_decode_option(self, r: valkey.Valkey):


### PR DESCRIPTION
The previous 0.3s sleep was sometimes insufficient for the BGSAVE to finish, resulting in the test failing with:

valkey.exceptions.ResponseError: Background save already in progress

which resulted in a flaky test. This commits adds a `wait_for_condition` helper that only triggers the second BGSAVE after Valkey reports that the first one finished.

Example of a previous failed run: https://github.com/valkey-io/valkey-py/actions/runs/30697266649/job/91362231887#step:6:372

### Pull Request check-list

<!-- Please make sure to review and check all of these items: -->

- [ ] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
