### PR TITLE
Fix RuntimeError when the node dict is mutated during initialize()

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -2668,6 +2668,72 @@ class TestNodesManager:
                 "startup_nodes could not agree on a valid slots cache"
             ), str(ex.value)
 
+    def test_init_slots_cache_concurrent_node_mutation(self):
+        """
+        Test that initialize() tolerates the node dict being mutated while it
+        is iterating.
+
+        With dynamic_startup_nodes (the default) initialize() ends with
+        `self.startup_nodes = tmp_nodes_cache`, so startup_nodes and
+        nodes_cache become the same dict. A MOVED redirect handled on another
+        thread then inserts into the very dict this loop is walking, raising
+        "RuntimeError: dictionary changed size during iteration".
+
+        The loop only advances past its first startup node when that node is
+        unreachable, which is the state a failover leaves behind.
+        """
+        cluster_slots = [
+            [0, 8191, ["127.0.0.1", 7000]],
+            [8192, 16383, ["127.0.0.1", 7001]],
+        ]
+        failed_over = []
+
+        with patch.object(
+            NodesManager, "create_valkey_node", autospec=True
+        ) as create_valkey_node:
+
+            def create_mocked_valkey_node(nodes_manager, host, port, **kwargs):
+                r_node = Valkey(host=host, port=port)
+
+                def execute_command(*args, **kwargs):
+                    if args[0] == "CLUSTER SLOTS":
+                        if failed_over and port == 7000:
+                            # Stand in for _update_moved_slots() inserting a
+                            # redirected node from another thread, while this
+                            # node is the one that just failed over.
+                            node = ClusterNode("127.0.0.2", port)
+                            nodes_manager.nodes_cache[node.name] = node
+                            raise ConnectionError(f"{host}:{port} is down")
+                        return cluster_slots
+                    elif args[0] == "INFO":
+                        return {"cluster_enabled": True}
+                    elif args[1] == "cluster-require-full-coverage":
+                        return {"cluster-require-full-coverage": "yes"}
+                    else:
+                        return None
+
+                r_node.execute_command = execute_command
+                return r_node
+
+            create_valkey_node.side_effect = create_mocked_valkey_node
+
+            rc = ValkeyCluster(
+                startup_nodes=[
+                    ClusterNode("127.0.0.1", 7000),
+                    ClusterNode("127.0.0.1", 7001),
+                ]
+            )
+            n_manager = rc.nodes_manager
+            # dynamic_startup_nodes aliases the two dicts to one object
+            assert n_manager.startup_nodes is n_manager.nodes_cache
+
+            failed_over.append(True)
+            # Must not raise RuntimeError; the second startup node still
+            # serves a full slots cache.
+            n_manager.initialize()
+
+        assert len(n_manager.slots_cache) == VALKEY_CLUSTER_HASH_SLOTS
+
     def test_cluster_one_instance(self):
         """
         If the cluster exists of only 1 node then there is some hacks that must

--- a/valkey/cluster.py
+++ b/valkey/cluster.py
@@ -1464,7 +1464,7 @@ class NodesManager:
         """
         return [
             node
-            for node in self.nodes_cache.values()
+            for node in list(self.nodes_cache.values())
             if node.server_type == server_type
         ]
 
@@ -1536,7 +1536,10 @@ class NodesManager:
         fully_covered = False
         kwargs = self.connection_kwargs
         exception = None
-        for startup_node in self.startup_nodes.values():
+        # Iterate over a snapshot: another thread handling a MOVED redirect or a
+        # node failure may insert into or pop from this dict while we are here,
+        # and with dynamic_startup_nodes it is the same object as nodes_cache.
+        for startup_node in list(self.startup_nodes.values()):
             try:
                 if startup_node.valkey_connection:
                     r = startup_node.valkey_connection
@@ -1545,7 +1548,7 @@ class NodesManager:
                     r = self.create_valkey_node(
                         startup_node.host, startup_node.port, **kwargs
                     )
-                    self.startup_nodes[startup_node.name].valkey_connection = r
+                    startup_node.valkey_connection = r
                 # Make sure cluster mode is enabled on this node
                 try:
                     cluster_slots = str_if_bytes(r.execute_command("CLUSTER SLOTS"))
@@ -1658,7 +1661,7 @@ class NodesManager:
 
     def close(self):
         self.default_node = None
-        for node in self.nodes_cache.values():
+        for node in list(self.nodes_cache.values()):
             if node.valkey_connection:
                 node.valkey_connection.close()
 
@@ -1680,15 +1683,15 @@ class NodesManager:
         return host, port
 
     def flush_cache(self):
-        for node in self.nodes_cache.values():
+        for node in list(self.nodes_cache.values()):
             node.flush_cache()
 
     def delete_command_from_cache(self, command):
-        for node in self.nodes_cache.values():
+        for node in list(self.nodes_cache.values()):
             node.delete_command_from_cache(command)
 
     def invalidate_key_from_cache(self, key):
-        for node in self.nodes_cache.values():
+        for node in list(self.nodes_cache.values()):
             node.invalidate_key_from_cache(key)
 
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Do tests and lints pass with this change?
- [ ] Do the CI tests pass with this change (enable it first in your forked repo and wait for the github action build to finish)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Is there an example added to the examples folder (if applicable)?

### Description of change

`NodesManager.initialize()` iterates `self.startup_nodes.values()` directly. With `dynamic_startup_nodes` enabled (the default), the tail of `initialize()` runs

```python
if self._dynamic_startup_nodes:
    # Populate the startup nodes with all discovered nodes
    self.startup_nodes = tmp_nodes_cache
```

so from that point on `startup_nodes` and `nodes_cache` are the **same dict object**. Anything that mutates `nodes_cache` also mutates `startup_nodes`.

Two paths mutate that dict in place, and both are reached from ordinary command execution on other threads:

- `NodesManager._update_moved_slots()` — `self.nodes_cache[redirected_node.name] = redirected_node`, when a MOVED redirect names a node not yet in the cache.
- `ValkeyCluster._execute_command()`, on `ConnectionError`/`TimeoutError` — `self.nodes_manager.startup_nodes.pop(target_node.name, None)` followed by `nodes_manager.initialize()`.

So one thread can be inside `initialize()` walking `startup_nodes` while another inserts or pops, and the client raises

```
RuntimeError: dictionary changed size during iteration
```

out of whatever user command happened to trigger the re-initialization. `RuntimeError` is neither `ValkeyError` nor `ValkeyClusterException`, so callers that catch the library's exception hierarchy cannot absorb it.

#### How we hit it

A production ElastiCache Valkey cluster (18 shards, cluster mode enabled) was upgraded in place, which fails the primary of each shard over in batches. Every worker re-initialized at once while MOVED redirects were still flowing. 47 requests failed with the traceback below over a ~9 minute window; each one surfaced as a 500 rather than a handled cluster error.

```
valkey.exceptions.ClusterDownError: The cluster is down

During handling of the above exception, another exception occurred:
  ...
  valkey/cluster.py  initialize
RuntimeError: dictionary changed size during iteration
```

An engine upgrade is not special here — any primary failover, resharding, or slot migration produces the same combination of MOVED traffic and connection errors.

#### Fix

Iterate over a snapshot in `initialize()` and in the other methods that walk `nodes_cache` (`get_nodes_by_server_type`, `close`, `flush_cache`, `delete_command_from_cache`, `invalidate_key_from_cache`). `list(d.values())` is atomic with respect to other threads, so the loop no longer observes a concurrent resize.

One related line: inside the loop, `self.startup_nodes[startup_node.name].valkey_connection = r` becomes `startup_node.valkey_connection = r`. It is the same object, and it drops a lookup that would `KeyError` if another thread popped that name in the meantime.

This does not make `NodesManager` fully thread-safe — it removes this specific crash. Locking the topology state is a larger change.

#### Test

`tests/test_cluster.py::TestNodesManager::test_init_slots_cache_concurrent_node_mutation`

Deterministic and single-threaded: a mocked `CLUSTER SLOTS` handler inserts into `nodes_cache` and then raises `ConnectionError`, which is what a just-failed-over node looks like. The insert mutates the dict `initialize()` is iterating, and the raise makes the loop advance to the next startup node — where the unpatched code raises `RuntimeError`. (The loop `break`s early on full coverage, so a reachable first node never reaches a second iteration; the failure is what exposes it.)

Verified in both directions on this branch: without the `cluster.py` change the test reproduces `RuntimeError: dictionary changed size during iteration`; with it, the second startup node serves a full 16384-slot cache.
